### PR TITLE
lock state file writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,3 +467,4 @@ Compared to the typical workflow, there's no need to name branches, run `git add
 | 5 | Invalid arguments or flags |
 | 6 | Disambiguation required (branch belongs to multiple stacks) |
 | 7 | Rebase already in progress |
+| 8 | Stack is locked by another process |

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cli/go-gh/v2/pkg/prompter"
@@ -51,6 +52,9 @@ func runAdd(cfg *config.Config, opts *addOptions, args []string) error {
 
 	result, err := loadStack(cfg, "")
 	if err != nil {
+		if errors.Is(err, ErrLockFailed) {
+			return ErrLockFailed
+		}
 		return ErrNotInStack
 	}
 	defer result.Lock.Unlock()

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cli/go-gh/v2/pkg/prompter"
@@ -52,12 +51,8 @@ func runAdd(cfg *config.Config, opts *addOptions, args []string) error {
 
 	result, err := loadStack(cfg, "")
 	if err != nil {
-		if errors.Is(err, ErrLockFailed) {
-			return ErrLockFailed
-		}
 		return ErrNotInStack
 	}
-	defer result.Lock.Unlock()
 	gitDir := result.GitDir
 	sf := result.StackFile
 	s := result.Stack
@@ -205,8 +200,7 @@ func runAdd(cfg *config.Config, opts *addOptions, args []string) error {
 	}
 
 	if err := stack.Save(gitDir, sf); err != nil {
-		cfg.Errorf("failed to save stack state: %s", err)
-		return ErrSilent
+		return handleSaveError(cfg, err)
 	}
 
 	// Print summary

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -53,6 +53,7 @@ func runAdd(cfg *config.Config, opts *addOptions, args []string) error {
 	if err != nil {
 		return ErrNotInStack
 	}
+	defer result.Lock.Unlock()
 	gitDir := result.GitDir
 	sf := result.StackFile
 	s := result.Stack

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -73,6 +73,12 @@ func runInit(cfg *config.Config, opts *initOptions) error {
 	}
 
 	// Load existing stack file
+	lock, err := stack.Lock(gitDir)
+	if err != nil {
+		cfg.Warningf("could not acquire stack lock: %s", err)
+	}
+	defer lock.Unlock()
+
 	sf, err := stack.Load(gitDir)
 	if err != nil {
 		cfg.Errorf("failed to load stack state: %s", err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -73,13 +73,6 @@ func runInit(cfg *config.Config, opts *initOptions) error {
 	}
 
 	// Load existing stack file
-	lock, err := stack.Lock(gitDir)
-	if err != nil {
-		cfg.Errorf("another process is currently editing the stack — try again later")
-		return ErrLockFailed
-	}
-	defer lock.Unlock()
-
 	sf, err := stack.Load(gitDir)
 	if err != nil {
 		cfg.Errorf("failed to load stack state: %s", err)
@@ -334,7 +327,7 @@ func runInit(cfg *config.Config, opts *initOptions) error {
 	syncStackPRs(cfg, &sf.Stacks[len(sf.Stacks)-1])
 
 	if err := stack.Save(gitDir, sf); err != nil {
-		return err
+		return handleSaveError(cfg, err)
 	}
 
 	// Print result

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -75,7 +75,8 @@ func runInit(cfg *config.Config, opts *initOptions) error {
 	// Load existing stack file
 	lock, err := stack.Lock(gitDir)
 	if err != nil {
-		cfg.Warningf("could not acquire stack lock: %s", err)
+		cfg.Errorf("another process is currently editing the stack — try again later")
+		return ErrLockFailed
 	}
 	defer lock.Unlock()
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cli/go-gh/v2/pkg/browser"
@@ -36,12 +35,8 @@ func runMerge(cfg *config.Config, target string) error {
 	// Standard stack loading and validation.
 	result, err := loadStack(cfg, "")
 	if err != nil {
-		if errors.Is(err, ErrLockFailed) {
-			return ErrLockFailed
-		}
 		return ErrNotInStack
 	}
-	defer result.Lock.Unlock()
 	s := result.Stack
 	currentBranch := result.CurrentBranch
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -44,7 +44,7 @@ func runMerge(cfg *config.Config, target string) error {
 	syncStackPRs(cfg, s)
 
 	// Persist the refreshed PR state.
-	_ = stack.Save(result.GitDir, result.StackFile)
+	stack.SaveNonBlocking(result.GitDir, result.StackFile)
 
 	// Resolve which branch to operate on.
 	var br *stack.BranchRef

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -37,6 +37,7 @@ func runMerge(cfg *config.Config, target string) error {
 	if err != nil {
 		return ErrNotInStack
 	}
+	defer result.Lock.Unlock()
 	s := result.Stack
 	currentBranch := result.CurrentBranch
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cli/go-gh/v2/pkg/browser"
@@ -35,6 +36,9 @@ func runMerge(cfg *config.Config, target string) error {
 	// Standard stack loading and validation.
 	result, err := loadStack(cfg, "")
 	if err != nil {
+		if errors.Is(err, ErrLockFailed) {
+			return ErrLockFailed
+		}
 		return ErrNotInStack
 	}
 	defer result.Lock.Unlock()

--- a/cmd/navigate.go
+++ b/cmd/navigate.go
@@ -73,6 +73,7 @@ func runNavigate(cfg *config.Config, delta int) error {
 	if err != nil {
 		return ErrNotInStack
 	}
+	defer result.Lock.Unlock()
 	s := result.Stack
 	currentBranch := result.CurrentBranch
 
@@ -187,6 +188,7 @@ func runNavigateToEnd(cfg *config.Config, top bool) error {
 	if err != nil {
 		return ErrNotInStack
 	}
+	defer result.Lock.Unlock()
 	s := result.Stack
 	currentBranch := result.CurrentBranch
 

--- a/cmd/navigate.go
+++ b/cmd/navigate.go
@@ -69,11 +69,10 @@ func BottomCmd(cfg *config.Config) *cobra.Command {
 }
 
 func runNavigate(cfg *config.Config, delta int) error {
-	result, err := loadStack(cfg, "")
+	result, err := loadStackReadOnly(cfg, "")
 	if err != nil {
 		return ErrNotInStack
 	}
-	defer result.Lock.Unlock()
 	s := result.Stack
 	currentBranch := result.CurrentBranch
 
@@ -184,11 +183,10 @@ func runNavigate(cfg *config.Config, delta int) error {
 }
 
 func runNavigateToEnd(cfg *config.Config, top bool) error {
-	result, err := loadStack(cfg, "")
+	result, err := loadStackReadOnly(cfg, "")
 	if err != nil {
 		return ErrNotInStack
 	}
-	defer result.Lock.Unlock()
 	s := result.Stack
 	currentBranch := result.CurrentBranch
 

--- a/cmd/navigate.go
+++ b/cmd/navigate.go
@@ -69,7 +69,7 @@ func BottomCmd(cfg *config.Config) *cobra.Command {
 }
 
 func runNavigate(cfg *config.Config, delta int) error {
-	result, err := loadStackReadOnly(cfg, "")
+	result, err := loadStack(cfg, "")
 	if err != nil {
 		return ErrNotInStack
 	}
@@ -183,7 +183,7 @@ func runNavigate(cfg *config.Config, delta int) error {
 }
 
 func runNavigateToEnd(cfg *config.Config, top bool) error {
-	result, err := loadStackReadOnly(cfg, "")
+	result, err := loadStack(cfg, "")
 	if err != nil {
 		return ErrNotInStack
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -45,6 +45,12 @@ func runPush(cfg *config.Config, opts *pushOptions) error {
 		return ErrNotInStack
 	}
 
+	lock, err := stack.Lock(gitDir)
+	if err != nil {
+		cfg.Warningf("could not acquire stack lock: %s", err)
+	}
+	defer lock.Unlock()
+
 	sf, err := stack.Load(gitDir)
 	if err != nil {
 		cfg.Errorf("failed to load stack state: %s", err)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -45,13 +45,6 @@ func runPush(cfg *config.Config, opts *pushOptions) error {
 		return ErrNotInStack
 	}
 
-	lock, err := stack.Lock(gitDir)
-	if err != nil {
-		cfg.Errorf("another process is currently editing the stack — try again later")
-		return ErrLockFailed
-	}
-	defer lock.Unlock()
-
 	sf, err := stack.Load(gitDir)
 	if err != nil {
 		cfg.Errorf("failed to load stack state: %s", err)
@@ -187,8 +180,7 @@ func runPush(cfg *config.Config, opts *pushOptions) error {
 	syncStackPRs(cfg, s)
 
 	if err := stack.Save(gitDir, sf); err != nil {
-		cfg.Errorf("failed to save stack state: %s", err)
-		return ErrSilent
+		return handleSaveError(cfg, err)
 	}
 
 	cfg.Successf("Pushed and synced %d branches", len(s.ActiveBranches()))

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -47,7 +47,8 @@ func runPush(cfg *config.Config, opts *pushOptions) error {
 
 	lock, err := stack.Lock(gitDir)
 	if err != nil {
-		cfg.Warningf("could not acquire stack lock: %s", err)
+		cfg.Errorf("another process is currently editing the stack — try again later")
+		return ErrLockFailed
 	}
 	defer lock.Unlock()
 

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -84,6 +84,9 @@ func runRebase(cfg *config.Config, opts *rebaseOptions) error {
 
 	result, err := loadStack(cfg, opts.branch)
 	if err != nil {
+		if errors.Is(err, ErrLockFailed) {
+			return ErrLockFailed
+		}
 		return ErrNotInStack
 	}
 	defer result.Lock.Unlock()
@@ -340,7 +343,8 @@ func continueRebase(cfg *config.Config, gitDir string) error {
 
 	lock, err := stack.Lock(gitDir)
 	if err != nil {
-		cfg.Warningf("could not acquire stack lock: %s", err)
+		cfg.Errorf("another process is currently editing the stack — try again later")
+		return ErrLockFailed
 	}
 	defer lock.Unlock()
 

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -84,12 +84,8 @@ func runRebase(cfg *config.Config, opts *rebaseOptions) error {
 
 	result, err := loadStack(cfg, opts.branch)
 	if err != nil {
-		if errors.Is(err, ErrLockFailed) {
-			return ErrLockFailed
-		}
 		return ErrNotInStack
 	}
-	defer result.Lock.Unlock()
 	sf := result.StackFile
 	s := result.Stack
 	currentBranch := result.CurrentBranch
@@ -340,13 +336,6 @@ func continueRebase(cfg *config.Config, gitDir string) error {
 		cfg.Errorf("no rebase in progress")
 		return ErrSilent
 	}
-
-	lock, err := stack.Lock(gitDir)
-	if err != nil {
-		cfg.Errorf("another process is currently editing the stack — try again later")
-		return ErrLockFailed
-	}
-	defer lock.Unlock()
 
 	sf, err := stack.Load(gitDir)
 	if err != nil {

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -86,6 +86,7 @@ func runRebase(cfg *config.Config, opts *rebaseOptions) error {
 	if err != nil {
 		return ErrNotInStack
 	}
+	defer result.Lock.Unlock()
 	sf := result.StackFile
 	s := result.Stack
 	currentBranch := result.CurrentBranch
@@ -336,6 +337,12 @@ func continueRebase(cfg *config.Config, gitDir string) error {
 		cfg.Errorf("no rebase in progress")
 		return ErrSilent
 	}
+
+	lock, err := stack.Lock(gitDir)
+	if err != nil {
+		cfg.Warningf("could not acquire stack lock: %s", err)
+	}
+	defer lock.Unlock()
 
 	sf, err := stack.Load(gitDir)
 	if err != nil {

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -305,7 +305,7 @@ func runRebase(cfg *config.Config, opts *rebaseOptions) error {
 
 	syncStackPRs(cfg, s)
 
-	_ = stack.Save(gitDir, sf)
+	stack.SaveNonBlocking(gitDir, sf)
 
 	merged := s.MergedBranches()
 	if len(merged) > 0 {
@@ -496,7 +496,7 @@ func continueRebase(cfg *config.Config, gitDir string) error {
 
 	syncStackPRs(cfg, s)
 
-	_ = stack.Save(gitDir, sf)
+	stack.SaveNonBlocking(gitDir, sf)
 
 	cfg.Printf("All branches in stack rebased locally with %s", s.Trunk.Branch)
 	cfg.Printf("To push up your changes and open/update the stack of PRs, run `%s`",

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -49,6 +49,7 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 	if err != nil {
 		return ErrNotInStack
 	}
+	defer result.Lock.Unlock()
 	gitDir := result.GitDir
 	sf := result.StackFile
 	s := result.Stack

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -221,7 +221,7 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 		} else {
 			// Persist refreshed PR state even on conflict, then bail out
 			// before pushing or reporting success.
-			_ = stack.Save(gitDir, sf)
+			stack.SaveNonBlocking(gitDir, sf)
 			return ErrConflict
 		}
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -47,12 +47,8 @@ conflicts interactively.`,
 func runSync(cfg *config.Config, opts *syncOptions) error {
 	result, err := loadStack(cfg, "")
 	if err != nil {
-		if errors.Is(err, ErrLockFailed) {
-			return ErrLockFailed
-		}
 		return ErrNotInStack
 	}
-	defer result.Lock.Unlock()
 	gitDir := result.GitDir
 	sf := result.StackFile
 	s := result.Stack
@@ -292,8 +288,7 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 	updateBaseSHAs(s)
 
 	if err := stack.Save(gitDir, sf); err != nil {
-		cfg.Errorf("failed to save stack state: %s", err)
-		return ErrSilent
+		return handleSaveError(cfg, err)
 	}
 
 	cfg.Printf("")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -47,6 +47,9 @@ conflicts interactively.`,
 func runSync(cfg *config.Config, opts *syncOptions) error {
 	result, err := loadStack(cfg, "")
 	if err != nil {
+		if errors.Is(err, ErrLockFailed) {
+			return ErrLockFailed
+		}
 		return ErrNotInStack
 	}
 	defer result.Lock.Unlock()

--- a/cmd/unstack.go
+++ b/cmd/unstack.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"errors"
-
 	"github.com/github/gh-stack/internal/config"
 	"github.com/github/gh-stack/internal/stack"
 	"github.com/spf13/cobra"
@@ -37,12 +35,8 @@ func UnstackCmd(cfg *config.Config) *cobra.Command {
 func runUnstack(cfg *config.Config, opts *unstackOptions) error {
 	result, err := loadStack(cfg, opts.target)
 	if err != nil {
-		if errors.Is(err, ErrLockFailed) {
-			return ErrLockFailed
-		}
 		return ErrNotInStack
 	}
-	defer result.Lock.Unlock()
 	gitDir := result.GitDir
 	sf := result.StackFile
 	s := result.Stack
@@ -56,8 +50,7 @@ func runUnstack(cfg *config.Config, opts *unstackOptions) error {
 	// Remove from local tracking
 	sf.RemoveStackForBranch(target)
 	if err := stack.Save(gitDir, sf); err != nil {
-		cfg.Errorf("failed to save stack state: %s", err)
-		return ErrSilent
+		return handleSaveError(cfg, err)
 	}
 	cfg.Successf("Stack removed from local tracking")
 

--- a/cmd/unstack.go
+++ b/cmd/unstack.go
@@ -37,6 +37,7 @@ func runUnstack(cfg *config.Config, opts *unstackOptions) error {
 	if err != nil {
 		return ErrNotInStack
 	}
+	defer result.Lock.Unlock()
 	gitDir := result.GitDir
 	sf := result.StackFile
 	s := result.Stack

--- a/cmd/unstack.go
+++ b/cmd/unstack.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/github/gh-stack/internal/config"
 	"github.com/github/gh-stack/internal/stack"
 	"github.com/spf13/cobra"
@@ -35,6 +37,9 @@ func UnstackCmd(cfg *config.Config) *cobra.Command {
 func runUnstack(cfg *config.Config, opts *unstackOptions) error {
 	result, err := loadStack(cfg, opts.target)
 	if err != nil {
+		if errors.Is(err, ErrLockFailed) {
+			return ErrLockFailed
+		}
 		return ErrNotInStack
 	}
 	defer result.Lock.Unlock()

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -138,12 +138,17 @@ func loadStack(cfg *config.Config, branch string) (*loadStackResult, error) {
 }
 
 // handleSaveError translates a stack.Save error into the appropriate user
-// message and exit error.  Lock contention returns ErrLockFailed (exit 8);
-// other write failures return ErrSilent (exit 1).
+// message and exit error.  Lock contention and stale-file detection both
+// return ErrLockFailed (exit 8); other write failures return ErrSilent (exit 1).
 func handleSaveError(cfg *config.Config, err error) error {
 	var lockErr *stack.LockError
 	if errors.As(err, &lockErr) {
 		cfg.Errorf("another process is currently editing the stack — try again later")
+		return ErrLockFailed
+	}
+	var staleErr *stack.StaleError
+	if errors.As(err, &staleErr) {
+		cfg.Errorf("stack file was modified by another process — please re-run the command")
 		return ErrLockFailed
 	}
 	cfg.Errorf("failed to save stack state: %s", err)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -26,6 +26,7 @@ var (
 	ErrInvalidArgs  = &ExitError{Code: 5} // invalid arguments or flags
 	ErrDisambiguate = &ExitError{Code: 6} // multiple stacks/remotes, can't auto-select
 	ErrRebaseActive = &ExitError{Code: 7} // rebase already in progress
+	ErrLockFailed   = &ExitError{Code: 8} // could not acquire stack file lock
 )
 
 // ExitError is returned by commands to indicate a specific exit code.
@@ -87,13 +88,13 @@ func loadStack(cfg *config.Config, branch string) (*loadStackResult, error) {
 
 	lock, err := stack.Lock(gitDir)
 	if err != nil {
-		cfg.Warningf("could not acquire stack lock: %s", err)
-		// Proceed without lock — better than failing entirely.
+		cfg.Errorf("another process is currently editing the stack — try again later")
+		return nil, ErrLockFailed
 	}
 	// Release the lock if we fail before returning it to the caller.
 	success := false
 	defer func() {
-		if !success && lock != nil {
+		if !success {
 			lock.Unlock()
 		}
 	}()
@@ -146,6 +147,63 @@ func loadStack(cfg *config.Config, branch string) (*loadStackResult, error) {
 		Stack:         s,
 		CurrentBranch: currentBranch,
 		Lock:          lock,
+	}, nil
+}
+
+// loadStackReadOnly loads the stack without acquiring an exclusive lock.
+// Use this for commands that only read the stack and never call Save().
+func loadStackReadOnly(cfg *config.Config, branch string) (*loadStackResult, error) {
+	gitDir, err := git.GitDir()
+	if err != nil {
+		cfg.Errorf("not a git repository")
+		return nil, fmt.Errorf("not a git repository")
+	}
+
+	sf, err := stack.Load(gitDir)
+	if err != nil {
+		cfg.Errorf("failed to load stack state: %s", err)
+		return nil, fmt.Errorf("failed to load stack state: %w", err)
+	}
+
+	branchFromArg := branch != ""
+	if branch == "" {
+		branch, err = git.CurrentBranch()
+		if err != nil {
+			cfg.Errorf("failed to get current branch: %s", err)
+			return nil, fmt.Errorf("failed to get current branch: %w", err)
+		}
+	}
+
+	s, err := resolveStack(sf, branch, cfg)
+	if err != nil {
+		if errors.Is(err, errInterrupt) {
+			return nil, errInterrupt
+		}
+		cfg.Errorf("%s", err)
+		return nil, err
+	}
+	if s == nil {
+		if branchFromArg {
+			cfg.Errorf("branch %q is not part of a stack", branch)
+		} else {
+			cfg.Errorf("current branch %q is not part of a stack", branch)
+		}
+		cfg.Printf("Checkout an existing stack using `%s` or create a new stack using `%s`",
+			cfg.ColorCyan("gh stack checkout"), cfg.ColorCyan("gh stack init"))
+		return nil, fmt.Errorf("branch %q is not part of a stack", branch)
+	}
+
+	currentBranch, err := git.CurrentBranch()
+	if err != nil {
+		cfg.Errorf("failed to get current branch: %s", err)
+		return nil, fmt.Errorf("failed to get current branch: %w", err)
+	}
+
+	return &loadStackResult{
+		GitDir:        gitDir,
+		StackFile:     sf,
+		Stack:         s,
+		CurrentBranch: currentBranch,
 	}, nil
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -71,7 +71,6 @@ type loadStackResult struct {
 	StackFile     *stack.StackFile
 	Stack         *stack.Stack
 	CurrentBranch string
-	Lock          *stack.FileLock // caller must defer Lock.Unlock() if non-nil
 }
 
 // loadStack is the standard way to obtain a Stack for the current (or given)
@@ -79,25 +78,15 @@ type loadStackResult struct {
 // branch, calls resolveStack (which may prompt for disambiguation), checks for
 // a nil stack, and re-reads the current branch (in case disambiguation caused
 // a checkout).  Errors are printed via cfg and returned.
+//
+// loadStack does NOT acquire the stack file lock.  The lock is acquired
+// automatically by stack.Save() when writing.
 func loadStack(cfg *config.Config, branch string) (*loadStackResult, error) {
 	gitDir, err := git.GitDir()
 	if err != nil {
 		cfg.Errorf("not a git repository")
 		return nil, fmt.Errorf("not a git repository")
 	}
-
-	lock, err := stack.Lock(gitDir)
-	if err != nil {
-		cfg.Errorf("another process is currently editing the stack — try again later")
-		return nil, ErrLockFailed
-	}
-	// Release the lock if we fail before returning it to the caller.
-	success := false
-	defer func() {
-		if !success {
-			lock.Unlock()
-		}
-	}()
 
 	sf, err := stack.Load(gitDir)
 	if err != nil {
@@ -140,71 +129,25 @@ func loadStack(cfg *config.Config, branch string) (*loadStackResult, error) {
 		return nil, fmt.Errorf("failed to get current branch: %w", err)
 	}
 
-	success = true
 	return &loadStackResult{
 		GitDir:        gitDir,
 		StackFile:     sf,
 		Stack:         s,
 		CurrentBranch: currentBranch,
-		Lock:          lock,
 	}, nil
 }
 
-// loadStackReadOnly loads the stack without acquiring an exclusive lock.
-// Use this for commands that only read the stack and never call Save().
-func loadStackReadOnly(cfg *config.Config, branch string) (*loadStackResult, error) {
-	gitDir, err := git.GitDir()
-	if err != nil {
-		cfg.Errorf("not a git repository")
-		return nil, fmt.Errorf("not a git repository")
+// handleSaveError translates a stack.Save error into the appropriate user
+// message and exit error.  Lock failures return ErrLockFailed (exit 8);
+// other write failures return ErrSilent (exit 1).
+func handleSaveError(cfg *config.Config, err error) error {
+	var lockErr *stack.LockError
+	if errors.As(err, &lockErr) {
+		cfg.Errorf("another process is currently editing the stack — try again later")
+		return ErrLockFailed
 	}
-
-	sf, err := stack.Load(gitDir)
-	if err != nil {
-		cfg.Errorf("failed to load stack state: %s", err)
-		return nil, fmt.Errorf("failed to load stack state: %w", err)
-	}
-
-	branchFromArg := branch != ""
-	if branch == "" {
-		branch, err = git.CurrentBranch()
-		if err != nil {
-			cfg.Errorf("failed to get current branch: %s", err)
-			return nil, fmt.Errorf("failed to get current branch: %w", err)
-		}
-	}
-
-	s, err := resolveStack(sf, branch, cfg)
-	if err != nil {
-		if errors.Is(err, errInterrupt) {
-			return nil, errInterrupt
-		}
-		cfg.Errorf("%s", err)
-		return nil, err
-	}
-	if s == nil {
-		if branchFromArg {
-			cfg.Errorf("branch %q is not part of a stack", branch)
-		} else {
-			cfg.Errorf("current branch %q is not part of a stack", branch)
-		}
-		cfg.Printf("Checkout an existing stack using `%s` or create a new stack using `%s`",
-			cfg.ColorCyan("gh stack checkout"), cfg.ColorCyan("gh stack init"))
-		return nil, fmt.Errorf("branch %q is not part of a stack", branch)
-	}
-
-	currentBranch, err := git.CurrentBranch()
-	if err != nil {
-		cfg.Errorf("failed to get current branch: %s", err)
-		return nil, fmt.Errorf("failed to get current branch: %w", err)
-	}
-
-	return &loadStackResult{
-		GitDir:        gitDir,
-		StackFile:     sf,
-		Stack:         s,
-		CurrentBranch: currentBranch,
-	}, nil
+	cfg.Errorf("failed to save stack state: %s", err)
+	return ErrSilent
 }
 
 // resolveStack finds the stack for the given branch, handling ambiguity when

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -138,7 +138,7 @@ func loadStack(cfg *config.Config, branch string) (*loadStackResult, error) {
 }
 
 // handleSaveError translates a stack.Save error into the appropriate user
-// message and exit error.  Lock failures return ErrLockFailed (exit 8);
+// message and exit error.  Lock contention returns ErrLockFailed (exit 8);
 // other write failures return ErrSilent (exit 1).
 func handleSaveError(cfg *config.Config, err error) error {
 	var lockErr *stack.LockError

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -70,6 +70,7 @@ type loadStackResult struct {
 	StackFile     *stack.StackFile
 	Stack         *stack.Stack
 	CurrentBranch string
+	Lock          *stack.FileLock // caller must defer Lock.Unlock() if non-nil
 }
 
 // loadStack is the standard way to obtain a Stack for the current (or given)
@@ -83,6 +84,19 @@ func loadStack(cfg *config.Config, branch string) (*loadStackResult, error) {
 		cfg.Errorf("not a git repository")
 		return nil, fmt.Errorf("not a git repository")
 	}
+
+	lock, err := stack.Lock(gitDir)
+	if err != nil {
+		cfg.Warningf("could not acquire stack lock: %s", err)
+		// Proceed without lock — better than failing entirely.
+	}
+	// Release the lock if we fail before returning it to the caller.
+	success := false
+	defer func() {
+		if !success && lock != nil {
+			lock.Unlock()
+		}
+	}()
 
 	sf, err := stack.Load(gitDir)
 	if err != nil {
@@ -125,11 +139,13 @@ func loadStack(cfg *config.Config, branch string) (*loadStackResult, error) {
 		return nil, fmt.Errorf("failed to get current branch: %w", err)
 	}
 
+	success = true
 	return &loadStackResult{
 		GitDir:        gitDir,
 		StackFile:     sf,
 		Stack:         s,
 		CurrentBranch: currentBranch,
+		Lock:          lock,
 	}, nil
 }
 

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -45,6 +45,7 @@ func runView(cfg *config.Config, opts *viewOptions) error {
 	if err != nil {
 		return ErrNotInStack
 	}
+	defer result.Lock.Unlock()
 	gitDir := result.GitDir
 	sf := result.StackFile
 	s := result.Stack

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -52,7 +52,7 @@ func runView(cfg *config.Config, opts *viewOptions) error {
 
 	// Sync PR state and save (best-effort).
 	syncStackPRs(cfg, s)
-	_ = stack.Save(gitDir, sf)
+	stack.SaveNonBlocking(gitDir, sf)
 
 	if opts.asJSON {
 		return viewJSON(cfg, s, currentBranch)

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -43,6 +44,9 @@ func ViewCmd(cfg *config.Config) *cobra.Command {
 func runView(cfg *config.Config, opts *viewOptions) error {
 	result, err := loadStack(cfg, "")
 	if err != nil {
+		if errors.Is(err, ErrLockFailed) {
+			return ErrLockFailed
+		}
 		return ErrNotInStack
 	}
 	defer result.Lock.Unlock()

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -44,18 +43,14 @@ func ViewCmd(cfg *config.Config) *cobra.Command {
 func runView(cfg *config.Config, opts *viewOptions) error {
 	result, err := loadStack(cfg, "")
 	if err != nil {
-		if errors.Is(err, ErrLockFailed) {
-			return ErrLockFailed
-		}
 		return ErrNotInStack
 	}
-	defer result.Lock.Unlock()
 	gitDir := result.GitDir
 	sf := result.StackFile
 	s := result.Stack
 	currentBranch := result.CurrentBranch
 
-	// Sync PR state
+	// Sync PR state and save (best-effort).
 	syncStackPRs(cfg, s)
 	_ = stack.Save(gitDir, sf)
 

--- a/internal/stack/lock.go
+++ b/internal/stack/lock.go
@@ -21,14 +21,14 @@ func (e *LockError) Unwrap() error { return e.Err }
 
 // LockTimeout is how long Lock() will wait for the exclusive lock before
 // giving up.  With the lock held only during file writes (milliseconds),
-// this timeout primarily guards against stuck or orphaned lock files.
+// this timeout primarily guards against a hung process holding the lock.
 const LockTimeout = 5 * time.Second
 
 // lockRetryInterval is the sleep between non-blocking lock attempts.
 const lockRetryInterval = 100 * time.Millisecond
 
 // FileLock provides an exclusive advisory lock on the stack file to prevent
-// concurrent Load-Modify-Save races between multiple gh-stack processes.
+// concurrent writes between multiple gh-stack processes.
 type FileLock struct {
 	f *os.File
 }

--- a/internal/stack/lock.go
+++ b/internal/stack/lock.go
@@ -9,10 +9,20 @@ import (
 
 const lockFileName = "gh-stack.lock"
 
+// LockError is returned when the stack file lock cannot be acquired.
+// Callers can check for this with errors.As to distinguish lock failures
+// from other errors.
+type LockError struct {
+	Err error
+}
+
+func (e *LockError) Error() string { return e.Err.Error() }
+func (e *LockError) Unwrap() error { return e.Err }
+
 // LockTimeout is how long Lock() will wait for the exclusive lock before
-// giving up.  This prevents processes (including AI agents) from hanging
-// indefinitely when another instance holds the lock.
-const LockTimeout = 30 * time.Second
+// giving up.  With the lock held only during file writes (milliseconds),
+// this timeout primarily guards against stuck or orphaned lock files.
+const LockTimeout = 5 * time.Second
 
 // lockRetryInterval is the sleep between non-blocking lock attempts.
 const lockRetryInterval = 100 * time.Millisecond
@@ -25,16 +35,10 @@ type FileLock struct {
 
 // Lock acquires an exclusive lock on the stack file in the given git directory.
 // It retries with a non-blocking attempt every 100ms for up to LockTimeout.
-// Callers must defer Unlock() to release the lock.
 //
-// Usage:
-//
-//	lock, err := stack.Lock(gitDir)
-//	if err != nil { ... }
-//	defer lock.Unlock()
-//	sf, err := stack.Load(gitDir)
-//	// ... modify sf ...
-//	stack.Save(gitDir, sf)
+// Most callers should not use Lock directly — stack.Save() acquires the lock
+// automatically.  Use Lock only when you need to hold the lock across multiple
+// operations (e.g. Load-Modify-Save as an atomic unit).
 func Lock(gitDir string) (*FileLock, error) {
 	path := filepath.Join(gitDir, lockFileName)
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)

--- a/internal/stack/lock.go
+++ b/internal/stack/lock.go
@@ -19,10 +19,20 @@ type LockError struct {
 func (e *LockError) Error() string { return e.Err.Error() }
 func (e *LockError) Unwrap() error { return e.Err }
 
+// StaleError is returned when the stack file was modified on disk since it
+// was loaded.  This indicates another process wrote to the file concurrently.
+// Callers can check for this with errors.As.
+type StaleError struct {
+	Err error
+}
+
+func (e *StaleError) Error() string { return e.Err.Error() }
+func (e *StaleError) Unwrap() error { return e.Err }
+
 // LockTimeout is how long Lock() will wait for the exclusive lock before
 // giving up.  With the lock held only during file writes (milliseconds),
 // this timeout primarily guards against a hung process holding the lock.
-const LockTimeout = 5 * time.Second
+var LockTimeout = 5 * time.Second
 
 // lockRetryInterval is the sleep between non-blocking lock attempts.
 const lockRetryInterval = 100 * time.Millisecond

--- a/internal/stack/lock.go
+++ b/internal/stack/lock.go
@@ -1,0 +1,52 @@
+package stack
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const lockFileName = "gh-stack.lock"
+
+// FileLock provides an exclusive advisory lock on the stack file to prevent
+// concurrent Load-Modify-Save races between multiple gh-stack processes.
+type FileLock struct {
+	f    *os.File
+	path string
+}
+
+// Lock acquires an exclusive lock on the stack file in the given git directory.
+// Callers must defer Unlock() to release the lock.
+//
+// Usage:
+//
+//	lock, err := stack.Lock(gitDir)
+//	if err != nil { ... }
+//	defer lock.Unlock()
+//	sf, err := stack.Load(gitDir)
+//	// ... modify sf ...
+//	stack.Save(gitDir, sf)
+func Lock(gitDir string) (*FileLock, error) {
+	path := filepath.Join(gitDir, lockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock file: %w", err)
+	}
+
+	if err := lockFile(f); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("acquiring lock: %w", err)
+	}
+
+	return &FileLock{f: f, path: path}, nil
+}
+
+// Unlock releases the lock and removes the lock file.
+func (l *FileLock) Unlock() {
+	if l == nil || l.f == nil {
+		return
+	}
+	unlockFile(l.f)
+	l.f.Close()
+	os.Remove(l.path)
+}

--- a/internal/stack/lock.go
+++ b/internal/stack/lock.go
@@ -4,18 +4,27 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 const lockFileName = "gh-stack.lock"
 
+// LockTimeout is how long Lock() will wait for the exclusive lock before
+// giving up.  This prevents processes (including AI agents) from hanging
+// indefinitely when another instance holds the lock.
+const LockTimeout = 30 * time.Second
+
+// lockRetryInterval is the sleep between non-blocking lock attempts.
+const lockRetryInterval = 100 * time.Millisecond
+
 // FileLock provides an exclusive advisory lock on the stack file to prevent
 // concurrent Load-Modify-Save races between multiple gh-stack processes.
 type FileLock struct {
-	f    *os.File
-	path string
+	f *os.File
 }
 
 // Lock acquires an exclusive lock on the stack file in the given git directory.
+// It retries with a non-blocking attempt every 100ms for up to LockTimeout.
 // Callers must defer Unlock() to release the lock.
 //
 // Usage:
@@ -33,20 +42,28 @@ func Lock(gitDir string) (*FileLock, error) {
 		return nil, fmt.Errorf("opening lock file: %w", err)
 	}
 
-	if err := lockFile(f); err != nil {
-		f.Close()
-		return nil, fmt.Errorf("acquiring lock: %w", err)
+	deadline := time.Now().Add(LockTimeout)
+	for {
+		err := tryLockFile(f)
+		if err == nil {
+			return &FileLock{f: f}, nil
+		}
+		if time.Now().After(deadline) {
+			f.Close()
+			return nil, fmt.Errorf("timed out waiting for stack lock after %s — another gh-stack process may be running", LockTimeout)
+		}
+		time.Sleep(lockRetryInterval)
 	}
-
-	return &FileLock{f: f, path: path}, nil
 }
 
-// Unlock releases the lock and removes the lock file.
+// Unlock releases the lock.  The lock file is intentionally left on disk to
+// avoid a race where another process opens the same path, blocks on flock,
+// then wakes up holding a lock on an unlinked inode while a third process
+// creates a new file and locks a different inode.
 func (l *FileLock) Unlock() {
 	if l == nil || l.f == nil {
 		return
 	}
 	unlockFile(l.f)
 	l.f.Close()
-	os.Remove(l.path)
 }

--- a/internal/stack/lock.go
+++ b/internal/stack/lock.go
@@ -52,9 +52,15 @@ func Lock(gitDir string) (*FileLock, error) {
 		if err == nil {
 			return &FileLock{f: f}, nil
 		}
+		if !isLockBusy(err) {
+			// Unexpected error (e.g. bad fd) — don't retry.
+			f.Close()
+			return nil, fmt.Errorf("locking stack file: %w", err)
+		}
 		if time.Now().After(deadline) {
 			f.Close()
-			return nil, fmt.Errorf("timed out waiting for stack lock after %s — another gh-stack process may be running", LockTimeout)
+			return nil, &LockError{Err: fmt.Errorf(
+				"timed out waiting for stack lock after %s — another gh-stack process may be running", LockTimeout)}
 		}
 		time.Sleep(lockRetryInterval)
 	}

--- a/internal/stack/lock_test.go
+++ b/internal/stack/lock_test.go
@@ -3,6 +3,7 @@ package stack
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,39 @@ func TestLock_NilUnlockSafe(t *testing.T) {
 	// Unlock on nil should not panic.
 	var lock *FileLock
 	lock.Unlock()
+}
+
+func TestLock_BlocksUntilReleased(t *testing.T) {
+	dir := t.TempDir()
+
+	lock1, err := Lock(dir)
+	require.NoError(t, err)
+
+	acquired := make(chan struct{})
+	go func() {
+		lock2, err := Lock(dir)
+		require.NoError(t, err)
+		close(acquired)
+		lock2.Unlock()
+	}()
+
+	// lock2 should be blocked while lock1 is held.
+	select {
+	case <-acquired:
+		t.Fatal("lock2 acquired while lock1 was still held")
+	case <-time.After(300 * time.Millisecond):
+		// expected — lock2 is waiting
+	}
+
+	lock1.Unlock()
+
+	// After releasing lock1, lock2 should acquire promptly.
+	select {
+	case <-acquired:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("lock2 did not acquire after lock1 was released")
+	}
 }
 
 func TestLock_SerializesConcurrentAccess(t *testing.T) {
@@ -55,4 +89,17 @@ func TestLock_SerializesConcurrentAccess(t *testing.T) {
 	final, err := Load(dir)
 	require.NoError(t, err)
 	assert.Len(t, final.Stacks, 10, "all concurrent writes should be preserved")
+}
+
+func TestLock_FileLeftOnDisk(t *testing.T) {
+	dir := t.TempDir()
+
+	lock, err := Lock(dir)
+	require.NoError(t, err)
+	lock.Unlock()
+
+	// Lock file should still exist after unlock (no os.Remove race).
+	lock2, err := Lock(dir)
+	require.NoError(t, err, "should be able to re-lock after unlock")
+	lock2.Unlock()
 }

--- a/internal/stack/lock_test.go
+++ b/internal/stack/lock_test.go
@@ -1,0 +1,58 @@
+package stack
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLock_Basic(t *testing.T) {
+	dir := t.TempDir()
+
+	lock, err := Lock(dir)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	lock.Unlock()
+}
+
+func TestLock_NilUnlockSafe(t *testing.T) {
+	// Unlock on nil should not panic.
+	var lock *FileLock
+	lock.Unlock()
+}
+
+func TestLock_SerializesConcurrentAccess(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write an initial stack file with 0 stacks.
+	sf := &StackFile{SchemaVersion: 1, Stacks: []Stack{}}
+	require.NoError(t, Save(dir, sf))
+
+	// Run 10 concurrent goroutines, each adding a stack under lock.
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			lock, err := Lock(dir)
+			require.NoError(t, err)
+			defer lock.Unlock()
+
+			loaded, err := Load(dir)
+			require.NoError(t, err)
+
+			loaded.AddStack(makeStack("main", "branch"))
+			require.NoError(t, Save(dir, loaded))
+		}(i)
+	}
+	wg.Wait()
+
+	// All 10 stacks should be present — no lost updates.
+	final, err := Load(dir)
+	require.NoError(t, err)
+	assert.Len(t, final.Stacks, 10, "all concurrent writes should be preserved")
+}

--- a/internal/stack/lock_test.go
+++ b/internal/stack/lock_test.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -32,9 +33,13 @@ func TestLock_BlocksUntilReleased(t *testing.T) {
 	require.NoError(t, err)
 
 	acquired := make(chan struct{})
+	errCh := make(chan error, 1)
 	go func() {
 		lock2, err := Lock(dir)
-		require.NoError(t, err)
+		if err != nil {
+			errCh <- err
+			return
+		}
 		close(acquired)
 		lock2.Unlock()
 	}()
@@ -43,6 +48,8 @@ func TestLock_BlocksUntilReleased(t *testing.T) {
 	select {
 	case <-acquired:
 		t.Fatal("lock2 acquired while lock1 was still held")
+	case err := <-errCh:
+		t.Fatalf("lock2 failed: %v", err)
 	case <-time.After(300 * time.Millisecond):
 		// expected — lock2 is waiting
 	}
@@ -53,6 +60,8 @@ func TestLock_BlocksUntilReleased(t *testing.T) {
 	select {
 	case <-acquired:
 		// success
+	case err := <-errCh:
+		t.Fatalf("lock2 failed after lock1 released: %v", err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("lock2 did not acquire after lock1 was released")
 	}
@@ -67,6 +76,7 @@ func TestLock_SerializesConcurrentAccess(t *testing.T) {
 
 	// Run 10 concurrent goroutines, each adding a stack under lock.
 	// Uses Lock + Load + SaveLocked for atomic read-modify-write.
+	errCh := make(chan error, 10)
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -74,17 +84,30 @@ func TestLock_SerializesConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 
 			lock, err := Lock(dir)
-			require.NoError(t, err)
+			if err != nil {
+				errCh <- fmt.Errorf("goroutine %d Lock: %w", idx, err)
+				return
+			}
 			defer lock.Unlock()
 
 			loaded, err := Load(dir)
-			require.NoError(t, err)
+			if err != nil {
+				errCh <- fmt.Errorf("goroutine %d Load: %w", idx, err)
+				return
+			}
 
 			loaded.AddStack(makeStack("main", "branch"))
-			require.NoError(t, SaveLocked(dir, loaded))
+			if err := SaveLocked(dir, loaded); err != nil {
+				errCh <- fmt.Errorf("goroutine %d SaveLocked: %w", idx, err)
+			}
 		}(i)
 	}
 	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Error(err)
+	}
 
 	// All 10 stacks should be present — no lost updates.
 	final, err := Load(dir)

--- a/internal/stack/lock_test.go
+++ b/internal/stack/lock_test.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -77,7 +78,7 @@ func TestLock_SerializesConcurrentAccess(t *testing.T) {
 	require.NoError(t, Save(dir, sf))
 
 	// Run 10 concurrent goroutines, each adding a stack under lock.
-	// Uses Lock + Load + SaveLocked for atomic read-modify-write.
+	// Uses Lock + Load + writeStackFile for atomic read-modify-write.
 	errCh := make(chan error, 10)
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -99,8 +100,8 @@ func TestLock_SerializesConcurrentAccess(t *testing.T) {
 			}
 
 			loaded.AddStack(makeStack("main", "branch"))
-			if err := SaveLocked(dir, loaded); err != nil {
-				errCh <- fmt.Errorf("goroutine %d SaveLocked: %w", idx, err)
+			if err := writeStackFile(dir, loaded); err != nil {
+				errCh <- fmt.Errorf("goroutine %d writeStackFile: %w", idx, err)
 			}
 		}(i)
 	}
@@ -131,4 +132,113 @@ func TestLock_FileLeftOnDisk(t *testing.T) {
 	lock2, err := Lock(dir)
 	require.NoError(t, err, "should be able to re-lock after unlock")
 	lock2.Unlock()
+}
+
+func TestLock_TimesOut(t *testing.T) {
+	dir := t.TempDir()
+
+	// Hold the lock so the second attempt can never acquire it.
+	lock1, err := Lock(dir)
+	require.NoError(t, err)
+	defer lock1.Unlock()
+
+	// Save original timeout and set a short one for the test.
+	origTimeout := LockTimeout
+	LockTimeout = 200 * time.Millisecond
+	defer func() { LockTimeout = origTimeout }()
+
+	start := time.Now()
+	lock2, err := Lock(dir)
+	elapsed := time.Since(start)
+
+	assert.Nil(t, lock2, "should not acquire lock")
+	require.Error(t, err)
+
+	var lockErr *LockError
+	require.True(t, errors.As(err, &lockErr), "error should be *LockError, got %T", err)
+	assert.Contains(t, lockErr.Error(), "timed out")
+
+	// Should have waited roughly LockTimeout before giving up.
+	assert.GreaterOrEqual(t, elapsed, 150*time.Millisecond, "should wait near the timeout")
+}
+
+func TestSave_DetectsStaleFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write an initial stack file.
+	sf := &StackFile{SchemaVersion: 1, Stacks: []Stack{}}
+	require.NoError(t, Save(dir, sf))
+
+	// Load — captures the on-disk checksum.
+	loaded, err := Load(dir)
+	require.NoError(t, err)
+
+	// Simulate another process: load, modify, save.
+	other, err := Load(dir)
+	require.NoError(t, err)
+	other.AddStack(makeStack("main", "sneaky"))
+	require.NoError(t, Save(dir, other))
+
+	// Our loaded copy tries to save — should detect staleness.
+	loaded.AddStack(makeStack("main", "my-branch"))
+	err = Save(dir, loaded)
+	require.Error(t, err)
+
+	var staleErr *StaleError
+	require.True(t, errors.As(err, &staleErr), "error should be *StaleError, got %T", err)
+	assert.Contains(t, staleErr.Error(), "modified by another process")
+}
+
+func TestSave_AllowsWriteWhenFileUnchanged(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write, load, modify, save — no concurrent changes.
+	sf := &StackFile{SchemaVersion: 1, Stacks: []Stack{}}
+	require.NoError(t, Save(dir, sf))
+
+	loaded, err := Load(dir)
+	require.NoError(t, err)
+
+	loaded.AddStack(makeStack("main", "feature"))
+	require.NoError(t, Save(dir, loaded))
+
+	// Verify the write actually persisted.
+	final, err := Load(dir)
+	require.NoError(t, err)
+	assert.Len(t, final.Stacks, 1)
+}
+
+func TestSave_AllowsFirstWrite(t *testing.T) {
+	dir := t.TempDir()
+
+	// File doesn't exist — Load returns nil checksum, Save should succeed.
+	sf, err := Load(dir)
+	require.NoError(t, err)
+	assert.Empty(t, sf.Stacks)
+
+	sf.AddStack(makeStack("main", "first"))
+	require.NoError(t, Save(dir, sf), "first save to a new file should succeed")
+
+	final, err := Load(dir)
+	require.NoError(t, err)
+	assert.Len(t, final.Stacks, 1)
+}
+
+func TestSave_DoubleSaveSucceeds(t *testing.T) {
+	dir := t.TempDir()
+
+	sf, err := Load(dir)
+	require.NoError(t, err)
+
+	sf.AddStack(makeStack("main", "first"))
+	require.NoError(t, Save(dir, sf), "first save should succeed")
+
+	// A second Save on the same instance must not spuriously fail —
+	// writeStackFile refreshes loadChecksum after writing.
+	sf.AddStack(makeStack("main", "second"))
+	require.NoError(t, Save(dir, sf), "second save on same instance should succeed")
+
+	final, err := Load(dir)
+	require.NoError(t, err)
+	assert.Len(t, final.Stacks, 2)
 }

--- a/internal/stack/lock_test.go
+++ b/internal/stack/lock_test.go
@@ -2,6 +2,8 @@ package stack
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -123,6 +125,9 @@ func TestLock_FileLeftOnDisk(t *testing.T) {
 	lock.Unlock()
 
 	// Lock file should still exist after unlock (no os.Remove race).
+	_, err = os.Stat(filepath.Join(dir, lockFileName))
+	require.NoError(t, err, "lock file should remain on disk after unlock")
+
 	lock2, err := Lock(dir)
 	require.NoError(t, err, "should be able to re-lock after unlock")
 	lock2.Unlock()

--- a/internal/stack/lock_test.go
+++ b/internal/stack/lock_test.go
@@ -66,6 +66,7 @@ func TestLock_SerializesConcurrentAccess(t *testing.T) {
 	require.NoError(t, Save(dir, sf))
 
 	// Run 10 concurrent goroutines, each adding a stack under lock.
+	// Uses Lock + Load + SaveLocked for atomic read-modify-write.
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -80,7 +81,7 @@ func TestLock_SerializesConcurrentAccess(t *testing.T) {
 			require.NoError(t, err)
 
 			loaded.AddStack(makeStack("main", "branch"))
-			require.NoError(t, Save(dir, loaded))
+			require.NoError(t, SaveLocked(dir, loaded))
 		}(i)
 	}
 	wg.Wait()

--- a/internal/stack/lock_unix.go
+++ b/internal/stack/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package stack
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(f *os.File) {
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/stack/lock_unix.go
+++ b/internal/stack/lock_unix.go
@@ -7,8 +7,10 @@ import (
 	"syscall"
 )
 
-func lockFile(f *os.File) error {
-	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+// tryLockFile attempts a non-blocking exclusive lock.
+// Returns nil on success, or an error if the lock is held by another process.
+func tryLockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 }
 
 func unlockFile(f *os.File) {

--- a/internal/stack/lock_unix.go
+++ b/internal/stack/lock_unix.go
@@ -13,6 +13,11 @@ func tryLockFile(f *os.File) error {
 	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 }
 
+// isLockBusy reports whether err indicates the lock is held by another process.
+func isLockBusy(err error) bool {
+	return err == syscall.EWOULDBLOCK
+}
+
 func unlockFile(f *os.File) {
 	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 }

--- a/internal/stack/lock_windows.go
+++ b/internal/stack/lock_windows.go
@@ -3,6 +3,7 @@
 package stack
 
 import (
+	"errors"
 	"os"
 
 	"golang.org/x/sys/windows"
@@ -20,6 +21,11 @@ func tryLockFile(f *os.File) error {
 		0,  // high word
 		ol,
 	)
+}
+
+// isLockBusy reports whether err indicates the lock is held by another process.
+func isLockBusy(err error) bool {
+	return errors.Is(err, windows.ERROR_LOCK_VIOLATION)
 }
 
 func unlockFile(f *os.File) {

--- a/internal/stack/lock_windows.go
+++ b/internal/stack/lock_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package stack
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(f *os.File) error {
+	// Lock the first byte exclusively (blocks until available).
+	ol := new(windows.Overlapped)
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,    // reserved
+		1,    // lock 1 byte
+		0,    // high word
+		ol,
+	)
+}
+
+func unlockFile(f *os.File) {
+	ol := new(windows.Overlapped)
+	_ = windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0, 1, 0, ol,
+	)
+}

--- a/internal/stack/lock_windows.go
+++ b/internal/stack/lock_windows.go
@@ -8,15 +8,16 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func lockFile(f *os.File) error {
-	// Lock the first byte exclusively (blocks until available).
+// tryLockFile attempts a non-blocking exclusive lock.
+// Returns nil on success, or an error if the lock is held by another process.
+func tryLockFile(f *os.File) error {
 	ol := new(windows.Overlapped)
 	return windows.LockFileEx(
 		windows.Handle(f.Fd()),
-		windows.LOCKFILE_EXCLUSIVE_LOCK,
-		0,    // reserved
-		1,    // lock 1 byte
-		0,    // high word
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,  // reserved
+		1,  // lock 1 byte
+		0,  // high word
 		ol,
 	)
 }

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,6 +1,8 @@
 package stack
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -168,6 +170,11 @@ type StackFile struct {
 	SchemaVersion int     `json:"schemaVersion"`
 	Repository    string  `json:"repository"`
 	Stacks        []Stack `json:"stacks"`
+
+	// loadChecksum is the SHA-256 of the raw file bytes at Load time.
+	// Save uses it to detect concurrent modifications (optimistic concurrency).
+	// nil means the file did not exist when loaded.
+	loadChecksum []byte
 }
 
 // FindAllStacksForBranch returns all stacks that contain the given branch.
@@ -233,11 +240,14 @@ func stackFilePath(gitDir string) string {
 
 // Load reads the stack file from the given git directory.
 // Returns an empty StackFile if the file does not exist.
+// The returned StackFile records a checksum of the on-disk content so that
+// Save can detect concurrent modifications.
 func Load(gitDir string) (*StackFile, error) {
 	path := stackFilePath(gitDir)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			// loadChecksum stays nil — sentinel for "file absent at load time".
 			return &StackFile{
 				SchemaVersion: schemaVersion,
 				Stacks:        []Stack{},
@@ -255,24 +265,32 @@ func Load(gitDir string) (*StackFile, error) {
 		return nil, fmt.Errorf("stack file has schema version %d, but this version of gh-stack only supports up to version %d — please upgrade gh-stack", sf.SchemaVersion, schemaVersion)
 	}
 
+	sum := sha256.Sum256(data)
+	sf.loadChecksum = sum[:]
 	return &sf, nil
 }
 
-// Save acquires an exclusive lock on the stack file, writes sf as JSON, and
-// releases the lock.  The lock is held only for the duration of the write.
-// Returns *LockError if the lock times out due to contention.
+// Save acquires an exclusive lock on the stack file, verifies the file hasn't
+// been modified since Load (optimistic concurrency), writes sf as JSON, and
+// releases the lock.  The lock is held only for the read-compare-write window.
+// Returns *LockError if the lock times out, or *StaleError if another process
+// modified the file since it was loaded.
 func Save(gitDir string, sf *StackFile) error {
 	lock, err := Lock(gitDir)
 	if err != nil {
 		return err // *LockError for contention, plain error for I/O failures
 	}
 	defer lock.Unlock()
+
+	if err := checkStale(gitDir, sf); err != nil {
+		return err
+	}
 	return writeStackFile(gitDir, sf)
 }
 
 // SaveNonBlocking attempts to save without blocking.  If another process holds
-// the lock, the save is silently skipped.  Use this for best-effort metadata
-// persistence (e.g. syncing PR state in view).
+// the lock or the file was modified since Load, the save is silently skipped.
+// Use this for best-effort metadata persistence (e.g. syncing PR state in view).
 func SaveNonBlocking(gitDir string, sf *StackFile) {
 	path := filepath.Join(gitDir, lockFileName)
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
@@ -285,14 +303,46 @@ func SaveNonBlocking(gitDir string, sf *StackFile) {
 	}
 	lock := &FileLock{f: f}
 	defer lock.Unlock()
+
+	if checkStale(gitDir, sf) != nil {
+		return
+	}
 	_ = writeStackFile(gitDir, sf)
 }
 
-// SaveLocked writes the stack file without acquiring the lock.  The caller
-// must already hold the lock (via Lock) to protect the write.  Use this when
-// you need an atomic Load-Modify-Save sequence.
-func SaveLocked(gitDir string, sf *StackFile) error {
-	return writeStackFile(gitDir, sf)
+// checkStale compares the current on-disk content against the checksum
+// captured at Load time.  Returns *StaleError if the file was modified
+// by another process.  The caller must hold the lock.
+func checkStale(gitDir string, sf *StackFile) error {
+	path := stackFilePath(gitDir)
+	data, err := os.ReadFile(path)
+
+	if errors.Is(err, os.ErrNotExist) {
+		// File absent on disk.
+		if sf.loadChecksum == nil {
+			return nil // was absent at Load time too — no conflict
+		}
+		// File existed at Load but is now gone.  Allow the write to
+		// recreate it rather than erroring; this is not a lost-update.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading stack file for staleness check: %w", err)
+	}
+
+	// File exists on disk.
+	if sf.loadChecksum == nil {
+		// File was absent at Load but another process created it.
+		return &StaleError{Err: fmt.Errorf(
+			"stack file was created by another process since it was loaded")}
+	}
+
+	sum := sha256.Sum256(data)
+	if !bytes.Equal(sf.loadChecksum, sum[:]) {
+		return &StaleError{Err: fmt.Errorf(
+			"stack file was modified by another process since it was loaded")}
+	}
+	return nil
 }
 
 func writeStackFile(gitDir string, sf *StackFile) error {
@@ -308,5 +358,9 @@ func writeStackFile(gitDir string, sf *StackFile) error {
 	if err := os.WriteFile(path, data, 0644); err != nil {
 		return fmt.Errorf("writing stack file: %w", err)
 	}
+	// Refresh checksum so a second Save on the same StackFile doesn't
+	// spuriously fail the staleness check.
+	sum := sha256.Sum256(data)
+	sf.loadChecksum = sum[:]
 	return nil
 }

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -260,13 +260,32 @@ func Load(gitDir string) (*StackFile, error) {
 
 // Save acquires an exclusive lock on the stack file, writes sf as JSON, and
 // releases the lock.  The lock is held only for the duration of the write.
+// Returns *LockError if the lock times out due to contention.
 func Save(gitDir string, sf *StackFile) error {
 	lock, err := Lock(gitDir)
 	if err != nil {
-		return &LockError{Err: err}
+		return err // *LockError for contention, plain error for I/O failures
 	}
 	defer lock.Unlock()
 	return writeStackFile(gitDir, sf)
+}
+
+// SaveNonBlocking attempts to save without blocking.  If another process holds
+// the lock, the save is silently skipped.  Use this for best-effort metadata
+// persistence (e.g. syncing PR state in view).
+func SaveNonBlocking(gitDir string, sf *StackFile) {
+	path := filepath.Join(gitDir, lockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return
+	}
+	if tryLockFile(f) != nil {
+		f.Close()
+		return
+	}
+	lock := &FileLock{f: f}
+	defer lock.Unlock()
+	_ = writeStackFile(gitDir, sf)
 }
 
 // SaveLocked writes the stack file without acquiring the lock.  The caller

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -258,8 +258,25 @@ func Load(gitDir string) (*StackFile, error) {
 	return &sf, nil
 }
 
-// Save writes the stack file to the given git directory.
+// Save acquires an exclusive lock on the stack file, writes sf as JSON, and
+// releases the lock.  The lock is held only for the duration of the write.
 func Save(gitDir string, sf *StackFile) error {
+	lock, err := Lock(gitDir)
+	if err != nil {
+		return &LockError{Err: err}
+	}
+	defer lock.Unlock()
+	return writeStackFile(gitDir, sf)
+}
+
+// SaveLocked writes the stack file without acquiring the lock.  The caller
+// must already hold the lock (via Lock) to protect the write.  Use this when
+// you need an atomic Load-Modify-Save sequence.
+func SaveLocked(gitDir string, sf *StackFile) error {
+	return writeStackFile(gitDir, sf)
+}
+
+func writeStackFile(gitDir string, sf *StackFile) error {
 	sf.SchemaVersion = schemaVersion
 	if sf.Stacks == nil {
 		sf.Stacks = []Stack{}

--- a/skills/gh-stack/SKILL.md
+++ b/skills/gh-stack/SKILL.md
@@ -732,6 +732,7 @@ gh stack unstack feature-auth --local
 | 5 | Invalid arguments | Fix the command invocation (check flags and arguments) |
 | 6 | Disambiguation required | A branch belongs to multiple stacks. Run `gh stack checkout <specific-branch>` to switch to a non-shared branch first |
 | 7 | Rebase already in progress | Run `gh stack rebase --continue` (after resolving conflicts) or `gh stack rebase --abort` to start over |
+| 8 | Stack is locked | Another `gh stack` process is editing the stack file. Wait and retry — the lock times out after 30 seconds |
 
 ## Known limitations
 

--- a/skills/gh-stack/SKILL.md
+++ b/skills/gh-stack/SKILL.md
@@ -732,7 +732,7 @@ gh stack unstack feature-auth --local
 | 5 | Invalid arguments | Fix the command invocation (check flags and arguments) |
 | 6 | Disambiguation required | A branch belongs to multiple stacks. Run `gh stack checkout <specific-branch>` to switch to a non-shared branch first |
 | 7 | Rebase already in progress | Run `gh stack rebase --continue` (after resolving conflicts) or `gh stack rebase --abort` to start over |
-| 8 | Stack is locked | Another `gh stack` process is editing the stack file. Wait and retry — the lock times out after 30 seconds |
+| 8 | Stack is locked | Another `gh stack` process is writing the stack file. Wait and retry — the lock times out after 5 seconds |
 
 ## Known limitations
 


### PR DESCRIPTION
**File Locking Implementation:**
- Added a new `FileLock` type in `internal/stack/lock.go` with cross-platform support (`lock_unix.go`, `lock_windows.go`) to acquire an exclusive lock on the stack file during writes, preventing concurrent modification by multiple processes. Includes a 5-second timeout and robust unlock logic. [[1]](diffhunk://#diff-132e733002b533bb46e70a7a064ac076cd273e4eaf1ede610cc6866666d97ee0R1-R73) [[2]](diffhunk://#diff-eee9a1f284a32cc8525f2a1edd1df74fcc92c361c588cfacd35f99a3c59bc08dR1-R18) [[3]](diffhunk://#diff-5838c6b0c3b5b66c8b477f3697205f532d19cf524eb64997840176eefd999a37R1-R31)
- Introduced unit tests in `lock_test.go` to verify locking behavior, including concurrent access and lock file persistence.

**Stack File Write Changes:**
- Modified `Save` in `internal/stack/stack.go` to acquire and release the lock around writes. Added `SaveLocked` for advanced use cases where the lock is held across multiple operations.

**Error Handling and User Feedback:**
- Added a new error type `LockError` and exit code for lock failures, updating all commands that save the stack file (`add.go`, `init.go`, `push.go`, `sync.go`, `unstack.go`) to use a new `handleSaveError` helper for clearer user messages when a lock cannot be acquired. [[1]](diffhunk://#diff-5b14f474a50427ede31c39509d3921643c7f757a8c680f3a8bdf8c072e1c2160R140-R152) [[2]](diffhunk://#diff-8e2b47f6c23a892f2967380c2b5d2ec57b434885ead6b4995bb6cb9c69695c74L203-R203) [[3]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL330-R330) [[4]](diffhunk://#diff-e8011aeef8362327cdc0e4492778f39d0eb835e4cafe821111e3446637cc862eL183-R183) [[5]](diffhunk://#diff-6f5f9ca9ac82cbfb03857438b7f2b2373c6ddf3db19f1f68e7074242baebaadcL291-R291) [[6]](diffhunk://#diff-098d6d897ee047835da856da95d93d6ca51338c7d90d6ba181ea43da45c08aa3L53-R53)
- Updated error codes and documentation to reflect the new lock failure scenario, including `README.md` and `skills/gh-stack/SKILL.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R470) [[2]](diffhunk://#diff-5b14f474a50427ede31c39509d3921643c7f757a8c680f3a8bdf8c072e1c2160R29) [[3]](diffhunk://#diff-af147f8f9745ec4c926f5c3effbd87eb585c4cdef2298412c3526efa03048323R735)

**Documentation and Comments:**
- Improved code comments and documentation to clarify locking behavior, error handling, and usage patterns for stack file operations.

**Best-effort Save in View:**
- Updated `view.go` to clarify that saving after syncing PR state is best-effort and should not block the user if locking fails.