### PR TITLE
prune merged branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,15 +310,20 @@ Performs a safe, non-interactive synchronization of the entire stack:
 3. **Cascade rebase** — rebases all stack branches onto their updated parents (only if trunk moved). If a conflict is detected, all branches are restored to their original state and you are advised to run `gh stack rebase` to resolve conflicts interactively
 4. **Push** — pushes all branches (uses `--force-with-lease` if a rebase occurred)
 5. **Sync PRs** — syncs PR state from GitHub and reports the status of each PR
+6. **Prune** — in interactive terminals, prompts to delete local branches for merged PRs. Use `--prune` to prune automatically
 
 | Flag | Description |
 |------|-------------|
 | `--remote <name>` | Remote to fetch from and push to (defaults to auto-detected remote) |
+| `--prune` | Delete local branches for merged PRs |
 
 **Examples:**
 
 ```sh
 gh stack sync
+
+# Sync and automatically prune merged branches
+gh stack sync --prune
 ```
 
 ### `gh stack push`
@@ -556,6 +561,7 @@ gh stack push
 
 # 8. When the first PR is merged, sync the stack
 gh stack sync
+# → prompts to prune merged branches (or use --prune to prune automatically and avoid the prompt)
 ```
 
 ## Abbreviated workflow

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -426,12 +426,11 @@ func clearPendingModifyState(cfg *config.Config, gitDir string) {
 // This is a best-effort operation: failures are reported as warnings but do
 // not cause the submit command to fail (the PRs are already created).
 func syncStack(cfg *config.Config, client github.ClientOps, s *stack.Stack) {
-	// Collect PR numbers in stack order (bottom to top).
+	// Collect PR numbers in stack order (bottom to top), including merged PRs.
+	// The API expects the full list — omitting merged PRs causes a
+	// "Stack contents have changed" rejection.
 	var prNumbers []int
 	for _, b := range s.Branches {
-		if b.IsMerged() {
-			continue
-		}
 		if b.PullRequest != nil {
 			prNumbers = append(prNumbers, b.PullRequest.Number)
 		}

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -730,7 +730,7 @@ func TestSyncStack_SkippedForSinglePR(t *testing.T) {
 	assert.False(t, updateCalled, "UpdateStack should not be called with fewer than 2 PRs")
 }
 
-func TestSyncStack_SkipsMergedBranches(t *testing.T) {
+func TestSyncStack_IncludesMergedBranches(t *testing.T) {
 	s := &stack.Stack{
 		Trunk: stack.BranchRef{Branch: "main"},
 		Branches: []stack.BranchRef{
@@ -752,7 +752,7 @@ func TestSyncStack_SkipsMergedBranches(t *testing.T) {
 	syncStack(cfg, mock, s)
 	cfg.Err.Close()
 
-	assert.Equal(t, []int{11, 12}, gotNumbers, "should only include non-merged PRs")
+	assert.Equal(t, []int{10, 11, 12}, gotNumbers, "should include merged PRs to keep API in sync")
 }
 
 func TestSyncStack_SkipsBranchesWithoutPR(t *testing.T) {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -417,6 +417,9 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 				if err := git.DeleteBranch(name, true); err != nil {
 					cfg.Warningf("Failed to delete %s: %v", name, err)
 				} else {
+					// Also remove the remote-tracking ref so that
+					// `git checkout <name>` doesn't recreate the branch.
+					_ = git.DeleteTrackingRef(remote, name)
 					cfg.Successf("Pruned %s (merged)", name)
 					pruned++
 				}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cli/go-gh/v2/pkg/prompter"
 	"github.com/github/gh-stack/internal/config"
 	"github.com/github/gh-stack/internal/git"
 	"github.com/github/gh-stack/internal/modify"
@@ -349,7 +350,35 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 	}
 
 	// --- Step 6: Prune merged branches (optional) ---
-	if opts.prune {
+	doPrune := opts.prune
+	if !doPrune {
+		// --prune was not provided. If interactive, prompt.
+		merged := s.MergedBranches()
+		var prunableCount int
+		for _, b := range merged {
+			if git.BranchExists(b.Branch) {
+				prunableCount++
+			}
+		}
+		if prunableCount > 0 && cfg.IsInteractive() {
+			prompt := fmt.Sprintf("Prune %d merged %s?",
+				prunableCount, plural(prunableCount, "branch", "branches"))
+			confirmed, err := confirmPrune(cfg, prompt, true)
+			if err != nil {
+				if isInterruptError(err) {
+					printInterrupt(cfg)
+					// Save state before exiting so PR sync isn't lost.
+					_ = stack.Save(gitDir, sf)
+					return ErrSilent
+				}
+				// On any other prompt error, skip pruning silently.
+			} else {
+				doPrune = confirmed
+			}
+		}
+	}
+
+	if doPrune {
 		merged := s.MergedBranches()
 		var prunable []string
 		for _, b := range merged {
@@ -395,7 +424,7 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 			if pruned > 0 {
 				cfg.Successf("Pruned %d merged %s", pruned, plural(pruned, "branch", "branches"))
 			}
-		} else {
+		} else if opts.prune {
 			cfg.Printf("")
 			cfg.Printf("No merged branches to prune")
 		}
@@ -451,4 +480,13 @@ func short(sha string) string {
 		return sha[:7]
 	}
 	return sha
+}
+
+// confirmPrune asks the user to confirm pruning via ConfirmFn or a terminal prompt.
+func confirmPrune(cfg *config.Config, prompt string, defaultValue bool) (bool, error) {
+	if cfg.ConfirmFn != nil {
+		return cfg.ConfirmFn(prompt, defaultValue)
+	}
+	p := prompter.New(cfg.In, cfg.Out, cfg.Err)
+	return p.Confirm(prompt, defaultValue)
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -14,6 +14,7 @@ import (
 
 type syncOptions struct {
 	remote string
+	prune  bool
 }
 
 func SyncCmd(cfg *config.Config) *cobra.Command {
@@ -34,13 +35,19 @@ This command performs a safe, non-interactive synchronization:
 
 If a rebase conflict is detected, all branches are restored to their
 original state and you are advised to run "gh stack rebase" to resolve
-conflicts interactively.`,
+conflicts interactively.
+
+Use --prune to delete local branches for merged PRs. Stack metadata is
+preserved so that rebase and display logic continue to work correctly.
+If you are on a branch that would be pruned, your checkout is moved to
+the nearest active branch or the trunk.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSync(cfg, opts)
 		},
 	}
 
 	cmd.Flags().StringVar(&opts.remote, "remote", "", "Remote to fetch from and push to (defaults to auto-detected remote)")
+	cmd.Flags().BoolVar(&opts.prune, "prune", false, "Delete local branches for merged PRs")
 
 	return cmd
 }
@@ -341,7 +348,60 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 		cfg.Printf("Merged: %s", strings.Join(names, ", "))
 	}
 
-	// --- Step 6: Update base SHAs and save ---
+	// --- Step 6: Prune merged branches (optional) ---
+	if opts.prune {
+		merged := s.MergedBranches()
+		var prunable []string
+		for _, b := range merged {
+			if git.BranchExists(b.Branch) {
+				prunable = append(prunable, b.Branch)
+			}
+		}
+
+		if len(prunable) > 0 {
+			// If the current branch is being pruned, switch away first.
+			needsSwitch := false
+			for _, name := range prunable {
+				if name == currentBranch {
+					needsSwitch = true
+					break
+				}
+			}
+			if needsSwitch {
+				switchTarget := trunk
+				for _, b := range s.Branches {
+					if !b.IsSkipped() {
+						switchTarget = b.Branch
+						break
+					}
+				}
+				if err := git.CheckoutBranch(switchTarget); err != nil {
+					cfg.Warningf("Failed to switch from %s to %s: %v", currentBranch, switchTarget, err)
+				} else {
+					currentBranch = switchTarget
+				}
+			}
+
+			cfg.Printf("")
+			pruned := 0
+			for _, name := range prunable {
+				if err := git.DeleteBranch(name, true); err != nil {
+					cfg.Warningf("Failed to delete %s: %v", name, err)
+				} else {
+					cfg.Successf("Pruned %s (merged)", name)
+					pruned++
+				}
+			}
+			if pruned > 0 {
+				cfg.Successf("Pruned %d merged %s", pruned, plural(pruned, "branch", "branches"))
+			}
+		} else {
+			cfg.Printf("")
+			cfg.Printf("No merged branches to prune")
+		}
+	}
+
+	// --- Step 7: Update base SHAs and save ---
 	updateBaseSHAs(s)
 
 	if err := stack.Save(gitDir, sf); err != nil {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -41,7 +41,7 @@ conflicts interactively.
 Use --prune to delete local branches for merged PRs. Stack metadata is
 preserved so that rebase and display logic continue to work correctly.
 If you are on a branch that would be pruned, your checkout is moved to
-the nearest active branch or the trunk.`,
+the first active branch in the stack, or the trunk if all are merged.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSync(cfg, opts)
 		},
@@ -417,9 +417,6 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 				if err := git.DeleteBranch(name, true); err != nil {
 					cfg.Warningf("Failed to delete %s: %v", name, err)
 				} else {
-					// Also remove the remote-tracking ref so that
-					// `git checkout <name>` doesn't recreate the branch.
-					_ = git.DeleteTrackingRef(remote, name)
 					cfg.Successf("Pruned %s (merged)", name)
 					pruned++
 				}
@@ -430,6 +427,13 @@ func runSync(cfg *config.Config, opts *syncOptions) error {
 		} else if opts.prune {
 			cfg.Printf("")
 			cfg.Printf("No merged branches to prune")
+		}
+
+		// Clean up remote-tracking refs for all merged branches, even if
+		// the local branch was already deleted. This prevents
+		// `git checkout <name>` from resurrecting the branch.
+		for _, b := range merged {
+			_ = git.DeleteTrackingRef(remote, b.Branch)
 		}
 	}
 

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1019,3 +1019,270 @@ func TestSync_MergedBranchDeletedFromRemote(t *testing.T) {
 	assert.Equal(t, "main", rebaseOntoCalls[0].newBase)
 	assert.Equal(t, "b1-stored-head-sha", rebaseOntoCalls[0].oldBase)
 }
+
+// TestSync_Prune_DeletesMergedBranches verifies that --prune deletes local
+// branches for merged PRs while keeping them in the stack metadata.
+func TestSync_Prune_DeletesMergedBranches(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	var deletedBranches []string
+
+	mock := newSyncMock(tmpDir, "b2")
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.DeleteBranchFn = func(name string, force bool) error {
+		deletedBranches = append(deletedBranches, name)
+		assert.True(t, force, "should force-delete merged branch")
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+	cmd := SyncCmd(cfg)
+	cmd.SetArgs([]string{"--prune"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"b1"}, deletedBranches)
+	assert.Contains(t, output, "Pruned b1 (merged)")
+	assert.Contains(t, output, "Pruned 1 merged branch")
+}
+
+// TestSync_Prune_SkipsNonExistentBranches verifies that --prune does not
+// attempt to delete branches that have already been removed locally.
+func TestSync_Prune_SkipsNonExistentBranches(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", Head: "sha-b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	mock := newSyncMock(tmpDir, "b2")
+	mock.BranchExistsFn = func(name string) bool {
+		return name != "b1" // b1 already deleted
+	}
+	mock.DeleteBranchFn = func(string, bool) error {
+		t.Fatal("DeleteBranch should not be called for non-existent branches")
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+	cmd := SyncCmd(cfg)
+	cmd.SetArgs([]string{"--prune"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.NoError(t, err)
+	assert.Contains(t, output, "No merged branches to prune")
+}
+
+// TestSync_Prune_SwitchesToLowestUnmergedBranch verifies that when the user is
+// on a merged branch being pruned, checkout moves to the lowest active branch.
+func TestSync_Prune_SwitchesToLowestUnmergedBranch(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2"},
+			{Branch: "b3"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	var deletedBranches []string
+	var checkoutTarget string
+
+	mock := newSyncMock(tmpDir, "b1") // currently on merged branch
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.CheckoutBranchFn = func(name string) error {
+		checkoutTarget = name
+		return nil
+	}
+	mock.DeleteBranchFn = func(name string, force bool) error {
+		deletedBranches = append(deletedBranches, name)
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+	cmd := SyncCmd(cfg)
+	cmd.SetArgs([]string{"--prune"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"b1"}, deletedBranches)
+	// Should have switched to b2 (first active branch), not trunk
+	assert.Equal(t, "b2", checkoutTarget)
+	assert.Contains(t, output, "Pruned b1 (merged)")
+}
+
+// TestSync_Prune_SwitchesToTrunkWhenAllMerged verifies that when all branches
+// are merged, checkout moves to the trunk.
+func TestSync_Prune_SwitchesToTrunkWhenAllMerged(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2", PullRequest: &stack.PullRequestRef{Number: 2, Merged: true}},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	var deletedBranches []string
+	var checkoutTarget string
+
+	mock := newSyncMock(tmpDir, "b1") // currently on merged branch
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.CheckoutBranchFn = func(name string) error {
+		checkoutTarget = name
+		return nil
+	}
+	mock.DeleteBranchFn = func(name string, force bool) error {
+		deletedBranches = append(deletedBranches, name)
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+	cmd := SyncCmd(cfg)
+	cmd.SetArgs([]string{"--prune"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"b1", "b2"}, deletedBranches)
+	// Should have switched to trunk since all branches are merged
+	assert.Equal(t, "main", checkoutTarget)
+	assert.Contains(t, output, "Pruned 2 merged branches")
+}
+
+// TestSync_NoPrune_DoesNotDeleteBranches verifies that without --prune,
+// merged branches are not deleted (default behavior is unchanged).
+func TestSync_NoPrune_DoesNotDeleteBranches(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	mock := newSyncMock(tmpDir, "b2")
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.DeleteBranchFn = func(string, bool) error {
+		t.Fatal("DeleteBranch should not be called without --prune")
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, _ := config.NewTestConfig()
+	cmd := SyncCmd(cfg)
+	// No --prune flag
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+}
+
+// TestSync_Prune_DeleteFailureContinues verifies that a failed branch deletion
+// logs a warning and does not abort the sync.
+func TestSync_Prune_DeleteFailureContinues(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2", PullRequest: &stack.PullRequestRef{Number: 2, Merged: true}},
+			{Branch: "b3"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	var deletedBranches []string
+
+	mock := newSyncMock(tmpDir, "b3")
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.DeleteBranchFn = func(name string, force bool) error {
+		if name == "b1" {
+			return fmt.Errorf("permission denied")
+		}
+		deletedBranches = append(deletedBranches, name)
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+	cmd := SyncCmd(cfg)
+	cmd.SetArgs([]string{"--prune"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.NoError(t, err)
+	// b1 failed, b2 succeeded
+	assert.Equal(t, []string{"b2"}, deletedBranches)
+	assert.Contains(t, output, "Failed to delete b1")
+	assert.Contains(t, output, "Pruned b2 (merged)")
+	assert.Contains(t, output, "Pruned 1 merged branch")
+}

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1035,12 +1035,17 @@ func TestSync_Prune_DeletesMergedBranches(t *testing.T) {
 	writeStackFile(t, tmpDir, s)
 
 	var deletedBranches []string
+	var deletedTrackingRefs []string
 
 	mock := newSyncMock(tmpDir, "b2")
 	mock.BranchExistsFn = func(name string) bool { return true }
 	mock.DeleteBranchFn = func(name string, force bool) error {
 		deletedBranches = append(deletedBranches, name)
 		assert.True(t, force, "should force-delete merged branch")
+		return nil
+	}
+	mock.DeleteTrackingRefFn = func(remote, branch string) error {
+		deletedTrackingRefs = append(deletedTrackingRefs, remote+"/"+branch)
 		return nil
 	}
 
@@ -1060,6 +1065,7 @@ func TestSync_Prune_DeletesMergedBranches(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"b1"}, deletedBranches)
+	assert.Equal(t, []string{"origin/b1"}, deletedTrackingRefs, "should delete remote-tracking ref for pruned branch")
 	assert.Contains(t, output, "Pruned b1 (merged)")
 	assert.Contains(t, output, "Pruned 1 merged branch")
 }
@@ -1087,6 +1093,12 @@ func TestSync_Prune_SkipsNonExistentBranches(t *testing.T) {
 		return nil
 	}
 
+	var deletedTrackingRefs []string
+	mock.DeleteTrackingRefFn = func(remote, branch string) error {
+		deletedTrackingRefs = append(deletedTrackingRefs, remote+"/"+branch)
+		return nil
+	}
+
 	restore := git.SetOps(mock)
 	defer restore()
 
@@ -1103,6 +1115,8 @@ func TestSync_Prune_SkipsNonExistentBranches(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Contains(t, output, "No merged branches to prune")
+	// Tracking ref should still be cleaned up even though local branch is gone
+	assert.Equal(t, []string{"origin/b1"}, deletedTrackingRefs, "should delete tracking ref even when local branch is already gone")
 }
 
 // TestSync_Prune_SwitchesToLowestUnmergedBranch verifies that when the user is

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1286,3 +1286,171 @@ func TestSync_Prune_DeleteFailureContinues(t *testing.T) {
 	assert.Contains(t, output, "Pruned b2 (merged)")
 	assert.Contains(t, output, "Pruned 1 merged branch")
 }
+
+// TestSync_InteractivePrune_PromptsAndPrunes verifies that when running in an
+// interactive terminal without --prune, the user is prompted and merged branches
+// are pruned when they confirm.
+func TestSync_InteractivePrune_PromptsAndPrunes(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	var deletedBranches []string
+	var promptShown string
+
+	mock := newSyncMock(tmpDir, "b2")
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.DeleteBranchFn = func(name string, force bool) error {
+		deletedBranches = append(deletedBranches, name)
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+	cfg.ForceInteractive = true
+	cfg.ConfirmFn = func(prompt string, defaultValue bool) (bool, error) {
+		promptShown = prompt
+		assert.True(t, defaultValue, "default should be yes")
+		return true, nil // user confirms
+	}
+
+	cmd := SyncCmd(cfg)
+	// No --prune flag
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.NoError(t, err)
+	assert.Contains(t, promptShown, "Prune 1 merged branch")
+	assert.Equal(t, []string{"b1"}, deletedBranches)
+	assert.Contains(t, output, "Pruned b1 (merged)")
+}
+
+// TestSync_InteractivePrune_UserDeclines verifies that when the user declines
+// the prune prompt, no branches are deleted.
+func TestSync_InteractivePrune_UserDeclines(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	mock := newSyncMock(tmpDir, "b2")
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.DeleteBranchFn = func(string, bool) error {
+		t.Fatal("DeleteBranch should not be called when user declines")
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, _ := config.NewTestConfig()
+	cfg.ForceInteractive = true
+	cfg.ConfirmFn = func(string, bool) (bool, error) {
+		return false, nil // user declines
+	}
+
+	cmd := SyncCmd(cfg)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+}
+
+// TestSync_NonInteractive_NoPrunePrompt verifies that when the terminal is not
+// interactive and --prune is not set, no prompt is shown and no branches are deleted.
+func TestSync_NonInteractive_NoPrunePrompt(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	mock := newSyncMock(tmpDir, "b2")
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.DeleteBranchFn = func(string, bool) error {
+		t.Fatal("DeleteBranch should not be called in non-interactive mode without --prune")
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, _ := config.NewTestConfig()
+	// ForceInteractive is false by default — simulates non-interactive/CI/agent
+
+	cmd := SyncCmd(cfg)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+}
+
+// TestSync_ExplicitPrune_SkipsPrompt verifies that --prune flag bypasses the
+// interactive prompt and prunes directly.
+func TestSync_ExplicitPrune_SkipsPrompt(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1", PullRequest: &stack.PullRequestRef{Number: 1, Merged: true}},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	var deletedBranches []string
+
+	mock := newSyncMock(tmpDir, "b2")
+	mock.BranchExistsFn = func(name string) bool { return true }
+	mock.DeleteBranchFn = func(name string, force bool) error {
+		deletedBranches = append(deletedBranches, name)
+		return nil
+	}
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, _ := config.NewTestConfig()
+	cfg.ForceInteractive = true
+	cfg.ConfirmFn = func(string, bool) (bool, error) {
+		t.Fatal("ConfirmFn should not be called when --prune is explicit")
+		return false, nil
+	}
+
+	cmd := SyncCmd(cfg)
+	cmd.SetArgs([]string{"--prune"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"b1"}, deletedBranches)
+}

--- a/docs/src/content/docs/guides/stacked-prs.md
+++ b/docs/src/content/docs/guides/stacked-prs.md
@@ -49,4 +49,4 @@ gh stack sync
 
 - **`gh stack push`** pushes branches only (uses `--force-with-lease` for safety). It does not create or update PRs.
 - **`gh stack submit`** pushes branches and creates or updates PRs, linking them as a Stack on GitHub.
-- **`gh stack sync`** is the all-in-one command: fetch, rebase, push, and sync PR state.
+- **`gh stack sync`** is the all-in-one command: fetch, rebase, push, sync PR state, and optionally prune local branches for merged PRs.

--- a/docs/src/content/docs/guides/workflows.md
+++ b/docs/src/content/docs/guides/workflows.md
@@ -134,6 +134,7 @@ This command:
 3. Rebases all remaining stack branches onto the updated trunk
 4. Pushes the updated branches
 5. Syncs PR state from GitHub
+6. Prompts to prune local branches for merged PRs (use `--prune` to prune automatically)
 
 If a conflict is detected during the rebase, all branches are restored to their original state, and you're advised to run `gh stack rebase` to resolve conflicts interactively.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -295,15 +295,20 @@ Performs a safe, non-interactive synchronization of the entire stack:
 3. **Cascade rebase** — rebases all stack branches onto their updated parents (only if trunk moved). If a conflict is detected, all branches are restored to their original state, and you are advised to run `gh stack rebase` to resolve conflicts interactively.
 4. **Push** — pushes all branches (uses `--force-with-lease` if a rebase occurred).
 5. **Sync PRs** — syncs PR state from GitHub and reports the status of each PR.
+6. **Prune** — in interactive terminals, prompts to delete local branches for merged PRs. Use `--prune` to prune automatically.
 
 | Flag | Description |
 |------|-------------|
 | `--remote <name>` | Remote to fetch from and push to (defaults to auto-detected remote) |
+| `--prune` | Delete local branches for merged PRs |
 
 **Examples:**
 
 ```sh
 gh stack sync
+
+# Sync and automatically prune merged branches
+gh stack sync --prune
 ```
 
 ### `gh stack rebase`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	// SelectFn, when non-nil, is called instead of prompting via the
 	// terminal. Used in tests to simulate interactive selection.
 	SelectFn func(prompt, defaultValue string, options []string) (int, error)
+
+	// ConfirmFn, when non-nil, is called instead of prompting via the
+	// terminal. Used in tests to simulate yes/no confirmation prompts.
+	ConfirmFn func(prompt string, defaultValue bool) (bool, error)
 }
 
 // New creates a new Config with terminal-aware output and color support.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -312,6 +312,11 @@ func DeleteRemoteBranch(remote, branch string) error {
 	return ops.DeleteRemoteBranch(remote, branch)
 }
 
+// DeleteTrackingRef deletes a local remote-tracking ref (e.g. refs/remotes/origin/branch).
+func DeleteTrackingRef(remote, branch string) error {
+	return ops.DeleteTrackingRef(remote, branch)
+}
+
 // ResetHard resets the current branch to the given ref.
 func ResetHard(ref string) error {
 	return ops.ResetHard(ref)

--- a/internal/git/gitops.go
+++ b/internal/git/gitops.go
@@ -48,6 +48,7 @@ type Ops interface {
 	DiffStatFiles(base, head string) ([]FileDiffStat, error)
 	DeleteBranch(name string, force bool) error
 	DeleteRemoteBranch(remote, branch string) error
+	DeleteTrackingRef(remote, branch string) error
 	ResetHard(ref string) error
 	SetUpstreamTracking(branch, remote string) error
 	MergeFF(target string) error
@@ -483,6 +484,10 @@ func (d *defaultOps) DeleteBranch(name string, force bool) error {
 
 func (d *defaultOps) DeleteRemoteBranch(remote, branch string) error {
 	return runSilent("push", remote, "--delete", branch)
+}
+
+func (d *defaultOps) DeleteTrackingRef(remote, branch string) error {
+	return runSilent("branch", "-dr", remote+"/"+branch)
 }
 
 func (d *defaultOps) ResetHard(ref string) error {

--- a/internal/git/mock_ops.go
+++ b/internal/git/mock_ops.go
@@ -36,6 +36,7 @@ type MockOps struct {
 	DiffStatFilesFn         func(string, string) ([]FileDiffStat, error)
 	DeleteBranchFn          func(string, bool) error
 	DeleteRemoteBranchFn    func(string, string) error
+	DeleteTrackingRefFn     func(string, string) error
 	ResetHardFn             func(string) error
 	SetUpstreamTrackingFn   func(string, string) error
 	MergeFFFn               func(string) error
@@ -283,6 +284,13 @@ func (m *MockOps) DeleteBranch(name string, force bool) error {
 func (m *MockOps) DeleteRemoteBranch(remote, branch string) error {
 	if m.DeleteRemoteBranchFn != nil {
 		return m.DeleteRemoteBranchFn(remote, branch)
+	}
+	return nil
+}
+
+func (m *MockOps) DeleteTrackingRef(remote, branch string) error {
+	if m.DeleteTrackingRefFn != nil {
+		return m.DeleteTrackingRefFn(remote, branch)
 	}
 	return nil
 }

--- a/internal/tui/modifyview/model.go
+++ b/internal/tui/modifyview/model.go
@@ -454,12 +454,16 @@ func (m *Model) currentMode() actionMode {
 	return modeNone
 }
 
-// moveCursor moves the cursor by delta to the next node.
+// moveCursor moves the cursor by delta, skipping merged branches.
 func (m *Model) moveCursor(delta int) {
 	next := m.cursor + delta
-	if next >= 0 && next < len(m.nodes) {
-		m.cursor = next
-		m.ensureVisible()
+	for next >= 0 && next < len(m.nodes) {
+		if !m.nodes[next].Ref.IsMerged() {
+			m.cursor = next
+			m.ensureVisible()
+			return
+		}
+		next += delta
 	}
 }
 
@@ -863,6 +867,11 @@ func (m Model) handleMouseClick(screenX, screenY int) (tea.Model, tea.Cmd) {
 
 	result := shared.HandleClick(screenX, screenY, nodes, m.width, m.height, m.scrollOffset, shared.ShouldShowHeader(m.width, m.height), false)
 	if result.NodeIndex < 0 {
+		return m, nil
+	}
+
+	// Don't allow selecting merged branches.
+	if m.nodes[result.NodeIndex].Ref.IsMerged() {
 		return m, nil
 	}
 

--- a/internal/tui/modifyview/model_test.go
+++ b/internal/tui/modifyview/model_test.go
@@ -756,3 +756,21 @@ func TestUndoRename_DoesNotAffectOtherRenames(t *testing.T) {
 	require.NotNil(t, m.nodes[0].PendingAction, "first rename should still be intact")
 	assert.Equal(t, "a-renamed", m.nodes[0].PendingAction.NewName, "first rename new name should be unchanged")
 }
+
+func TestCursorNavigation_SkipsMergedBranches(t *testing.T) {
+	nodes := []ModifyBranchNode{
+		makeNode("a", true, 0),
+		makeMergedNode("merged", 1),
+		makeNode("c", false, 2),
+	}
+	m := New(nodes, testTrunk, "1.0.0")
+	require.Equal(t, 0, m.cursor, "cursor should start on first non-merged")
+
+	// Move down should skip merged and land on c
+	m = sendKey(t, m, runeKey('j'))
+	assert.Equal(t, 2, m.cursor, "down should skip merged branch")
+
+	// Move up should skip merged and land back on a
+	m = sendKey(t, m, runeKey('k'))
+	assert.Equal(t, 0, m.cursor, "up should skip merged branch")
+}

--- a/internal/tui/stackview/model.go
+++ b/internal/tui/stackview/model.go
@@ -83,12 +83,22 @@ func New(nodes []BranchNode, trunk stack.BranchRef, version string) Model {
 	h := help.New()
 	h.ShowAll = true
 
-	// Cursor starts at the current branch, or top of stack
+	// Cursor starts at the current branch, or first non-merged branch
 	cursor := 0
+	found := false
 	for i, n := range nodes {
-		if n.IsCurrent {
+		if n.IsCurrent && !n.Ref.IsMerged() {
 			cursor = i
+			found = true
 			break
+		}
+	}
+	if !found {
+		for i, n := range nodes {
+			if !n.Ref.IsMerged() {
+				cursor = i
+				break
+			}
 		}
 	}
 
@@ -124,17 +134,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case key.Matches(msg, keys.Up):
-			if m.cursor > 0 {
-				m.cursor--
-				m.ensureVisible()
-			}
+			m.moveCursor(-1)
 			return m, nil
 
 		case key.Matches(msg, keys.Down):
-			if m.cursor < len(m.nodes)-1 {
-				m.cursor++
-				m.ensureVisible()
-			}
+			m.moveCursor(1)
 			return m, nil
 
 		case key.Matches(msg, keys.ToggleCommits):
@@ -165,7 +169,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, keys.Checkout):
 			if m.cursor >= 0 && m.cursor < len(m.nodes) {
 				node := m.nodes[m.cursor]
-				if !node.IsCurrent {
+				if !node.IsCurrent && !node.Ref.IsMerged() {
 					m.checkoutBranch = node.Ref.Branch
 					return m, tea.Quit
 				}
@@ -226,6 +230,11 @@ func (m Model) handleMouseClick(screenX, screenY int) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Don't allow selecting merged branches.
+	if m.nodes[result.NodeIndex].Ref.IsMerged() {
+		return m, nil
+	}
+
 	m.cursor = result.NodeIndex
 
 	if result.OpenURL != "" {
@@ -246,6 +255,19 @@ func (m Model) handleMouseClick(screenX, screenY int) (tea.Model, tea.Cmd) {
 // nodeLineCount returns how many rendered lines a node occupies.
 func (m Model) nodeLineCount(idx int) int {
 	return shared.NodeLineCount(toBranchNodeData(m.nodes[idx]))
+}
+
+// moveCursor moves the cursor by delta, skipping merged branches.
+func (m *Model) moveCursor(delta int) {
+	next := m.cursor + delta
+	for next >= 0 && next < len(m.nodes) {
+		if !m.nodes[next].Ref.IsMerged() {
+			m.cursor = next
+			m.ensureVisible()
+			return
+		}
+		next += delta
+	}
 }
 
 // ensureVisible adjusts scroll offset so the cursor is visible.

--- a/internal/tui/stackview/model_test.go
+++ b/internal/tui/stackview/model_test.go
@@ -341,3 +341,50 @@ func TestScrollClamp_CannotScrollPastContent(t *testing.T) {
 	view := m.View()
 	assert.Contains(t, view, "b1", "content should still be visible after excessive scrolling")
 }
+
+func TestUpdate_CursorSkipsMergedBranches(t *testing.T) {
+	nodes := makeNodes("b1", "b2", "b3")
+	nodes[1].Ref.PullRequest = &stack.PullRequestRef{Number: 2, Merged: true}
+	m := New(nodes, testTrunk, "0.0.1")
+	assert.Equal(t, 0, m.cursor, "cursor should start on first non-merged branch")
+
+	// Down should skip b2 (merged) and land on b3
+	updated, _ := m.Update(keyMsg("down"))
+	m = updated.(Model)
+	assert.Equal(t, 2, m.cursor, "down should skip merged b2 and land on b3")
+
+	// Up should skip b2 (merged) and land back on b1
+	updated, _ = m.Update(keyMsg("up"))
+	m = updated.(Model)
+	assert.Equal(t, 0, m.cursor, "up should skip merged b2 and land on b1")
+}
+
+func TestNew_CursorSkipsMergedBranch(t *testing.T) {
+	nodes := makeNodes("b1", "b2", "b3")
+	nodes[0].Ref.PullRequest = &stack.PullRequestRef{Number: 1, Merged: true}
+	m := New(nodes, testTrunk, "0.0.1")
+	assert.Equal(t, 1, m.cursor, "cursor should skip merged b1 and start on b2")
+}
+
+func TestNew_CursorSkipsMergedCurrentBranch(t *testing.T) {
+	nodes := makeNodes("b1", "b2", "b3")
+	nodes[0].IsCurrent = true
+	nodes[0].Ref.PullRequest = &stack.PullRequestRef{Number: 1, Merged: true}
+	m := New(nodes, testTrunk, "0.0.1")
+	assert.Equal(t, 1, m.cursor, "cursor should not start on merged current branch")
+}
+
+func TestUpdate_EnterOnMergedDoesNothing(t *testing.T) {
+	// All non-merged so we can navigate, but force cursor onto a merged node
+	// by having b1 active and b2 merged and b3 active.
+	nodes := makeNodes("b1", "b2")
+	nodes[0].Ref.PullRequest = &stack.PullRequestRef{Number: 1, Merged: true}
+	m := New(nodes, testTrunk, "0.0.1")
+	// Cursor is on b2 (first non-merged). Manually set to b1 to test guard.
+	m.cursor = 0
+
+	updated, cmd := m.Update(keyMsg("enter"))
+	m = updated.(Model)
+	assert.Equal(t, "", m.CheckoutBranch(), "enter on merged branch should not set checkout")
+	assert.Nil(t, cmd, "enter on merged branch should not quit")
+}

--- a/skills/gh-stack/SKILL.md
+++ b/skills/gh-stack/SKILL.md
@@ -7,7 +7,7 @@ description: >
   branch chains, or incremental code review workflows.
 metadata:
   author: github
-  version: "0.0.3"
+  version: "0.0.4"
 ---
 
 # gh-stack

--- a/skills/gh-stack/SKILL.md
+++ b/skills/gh-stack/SKILL.md
@@ -152,6 +152,7 @@ Small, incidental fixes (e.g., fixing a typo you noticed) can go in the current 
 | Create PRs as ready for review | `gh stack submit --auto --open` |
 | Sync (fetch, rebase, push) | `gh stack sync` |
 | Sync with specific remote | `gh stack sync --remote origin` |
+| Sync and prune merged branches | `gh stack sync --prune` |
 | Rebase entire stack | `gh stack rebase` |
 | Rebase upstack only | `gh stack rebase --upstack` |
 | Continue after conflict | `gh stack rebase --continue` |
@@ -305,7 +306,12 @@ gh stack push
 ```bash
 # Single command: fetch, rebase, push, sync PR state
 gh stack sync
+
+# Sync and automatically clean up local branches for merged PRs
+gh stack sync --prune
 ```
+
+> **Note for agents:** In non-interactive environments, the prune prompt is not shown. Use `--prune` explicitly to delete local branches for merged PRs.
 
 ### Squash-merge recovery
 
@@ -615,6 +621,7 @@ gh stack sync [flags]
 | Flag | Description |
 |------|-------------|
 | `--remote <name>` | Remote to fetch from and push to (use if multiple remotes exist) |
+| `--prune` | Delete local branches for merged PRs |
 
 **What it does (in order):**
 
@@ -623,6 +630,7 @@ gh stack sync [flags]
 3. **Cascade rebase** all stack branches onto their updated parents (only if trunk moved). Handles merged PRs automatically. If a conflict is detected, **all branches are restored** to their pre-rebase state and the command exits with code 3 — see [Handle rebase conflicts](#handle-rebase-conflicts-agent-workflow) for the resolution workflow
 4. **Push** all active branches atomically
 5. **Sync PR state** from GitHub and report the status of each PR
+6. **Prune** — in interactive terminals, prompts to delete local branches for merged PRs. Use `--prune` to skip the prompt. In non-interactive environments, pruning only happens when `--prune` is passed explicitly
 
 **Output (stderr):**
 
@@ -632,6 +640,7 @@ gh stack sync [flags]
 - `✓ Pushed N branches`
 - `✓ PR #N (<branch>) — Open` per branch
 - `Merged: #N, #M` for merged branches
+- `✓ Pruned <branch> (merged)` per pruned branch (when pruning)
 - `✓ Stack synced`
 
 ---


### PR DESCRIPTION
Prune merged branches during sync

Add a `--prune` flag to `gh stack sync` that deletes local branches (and their remote-tracking refs) for merged PRs. In interactive terminals, users are prompted if they would like to prune merged branches. Non-interactive sessions (agents) require the explicit flag.

### Changes

- **Prune flag** (`cmd/sync.go`): New `--prune` flag deletes local branches for merged PRs. Deletes both the local branch (`git branch -D`) and the remote-tracking ref (`git branch -dr`) so `git checkout` can't resurrect the branch. If the user is on a pruned branch, checkout moves to the nearest active branch or trunk.
- **Interactive prompt** (`cmd/sync.go`): When `--prune` is not set and the terminal is interactive, prompts `"Prune N merged branches?"` with default yes. Skipped entirely in non-interactive sessions.
- **ConfirmFn hook** (`internal/config/config.go`): New test hook following the existing `SelectFn` pattern — allows tests to inject mock confirm responses.
- **DeleteTrackingRef** (`internal/git`): New git operation to delete local remote-tracking refs (`git branch -dr origin/<branch>`).
- **TUI merged-branch guards** (`internal/tui/stackview`, `internal/tui/modifyview`): Merged branches can no longer be selected via keyboard navigation, mouse click, or Enter/checkout in either the view or modify TUI. Cursor skips over merged nodes.
- **Stack API fix** (`cmd/submit.go`): Include merged PRs in the PUT payload to the stacks API — omitting them caused "Stack contents have changed" rejections on partially-merged stacks.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>