### PR TITLE
alert for unsupported auth tokens

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -183,7 +183,7 @@ func checkoutRemoteStack(cfg *config.Config, sf *stack.StackFile, gitDir string,
 	if err != nil {
 		var httpErr *api.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
-			cfg.Errorf("Stacked PRs are not enabled for this repository")
+			warnStacksUnavailableOrPAT(cfg)
 			return nil, "", ErrAPIFailure
 		}
 		cfg.Errorf("failed to list stacks: %v", err)

--- a/cmd/checkout_test.go
+++ b/cmd/checkout_test.go
@@ -158,6 +158,7 @@ func TestCheckout_NumericTarget_StacksNotAvailable(t *testing.T) {
 	require.NoError(t, stack.Save(gitDir, &stack.StackFile{SchemaVersion: 1, Stacks: []stack.Stack{}}))
 
 	cfg, outR, errR := config.NewTestConfig()
+	setTestTokenForHost(cfg, "gho_test_oauth_token")
 	cfg.GitHubClientOverride = &github.MockClient{
 		ListStacksFn: func() ([]github.RemoteStack, error) {
 			return nil, &api.HTTPError{StatusCode: 404, Message: "Not Found"}

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -310,7 +310,7 @@ func listStacksSafe(cfg *config.Config, client github.ClientOps) ([]github.Remot
 	if err != nil {
 		var httpErr *api.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
-			cfg.Warningf("Stacked PRs are not enabled for this repository")
+			warnStacksUnavailableOrPAT(cfg)
 			return nil, ErrStacksUnavailable
 		}
 		cfg.Errorf("failed to list stacks: %v", err)
@@ -510,7 +510,7 @@ func createLink(cfg *config.Config, client github.ClientOps, prNumbers []int) er
 				cfg.Errorf("Cannot create stack: %s", httpErr.Message)
 				return ErrAPIFailure
 			case 404:
-				cfg.Warningf("Stacked PRs are not enabled for this repository")
+				warnStacksUnavailableOrPAT(cfg)
 				return ErrStacksUnavailable
 			default:
 				cfg.Errorf("Failed to create stack (HTTP %d): %s", httpErr.StatusCode, httpErr.Message)

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -244,6 +244,7 @@ func TestLink_DuplicateArgs(t *testing.T) {
 
 func TestLink_StacksUnavailable(t *testing.T) {
 	cfg, _, errR := config.NewTestConfig()
+	setTestTokenForHost(cfg, "gho_test_oauth_token")
 	cfg.GitHubClientOverride = &github.MockClient{
 		FindPRByNumberFn: func(n int) (*github.PullRequest, error) {
 			return &github.PullRequest{Number: n, HeadRefName: "b", BaseRefName: "main"}, nil

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -99,11 +99,16 @@ func runSubmit(cfg *config.Config, opts *submitOptions) error {
 		return ErrAPIFailure
 	}
 
+	// Pre-flight: abort early if the user is authenticating with a PAT.
+	if cfg.WarnIfPAT() {
+		return ErrStacksUnavailable
+	}
+
 	// Verify that the repository has stacked PRs enabled.
 	stacksAvailable := s.ID != ""
 	if !stacksAvailable {
 		if _, err := client.ListStacks(); err != nil {
-			cfg.Warningf("Stacked PRs are not enabled for this repository")
+			warnStacksUnavailableOrPAT(cfg)
 			if cfg.IsInteractive() {
 				p := prompter.New(cfg.In, cfg.Out, cfg.Err)
 				proceed, promptErr := p.Confirm("Would you still like to create regular PRs?", false)
@@ -491,7 +496,7 @@ func createNewStack(cfg *config.Config, client github.ClientOps, s *stack.Stack,
 	case 422:
 		handleCreate422(cfg, httpErr, prNumbers)
 	case 404:
-		cfg.Warningf("Stacked PRs are not enabled for this repository")
+		warnStacksUnavailableOrPAT(cfg)
 	default:
 		cfg.Warningf("Failed to create stack on GitHub: %s", httpErr.Message)
 	}

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -1042,6 +1042,10 @@ func TestSubmit_PreflightCheck_404_BailsOut(t *testing.T) {
 		},
 	}
 
+	// Use an OAuth token so the PAT pre-flight check passes and we
+	// exercise the ListStacks 404 path.
+	setTestTokenForHost(cfg, "gho_test_oauth_token")
+
 	cmd := SubmitCmd(cfg)
 	cmd.SetArgs([]string{"--auto"})
 	cmd.SetOut(io.Discard)
@@ -1092,6 +1096,10 @@ func TestSubmit_PreflightCheck_404_Interactive_UserDeclinesAborts(t *testing.T) 
 			return nil, &api.HTTPError{StatusCode: 404, Message: "Not Found"}
 		},
 	}
+
+	// Use an OAuth token so the PAT pre-flight check passes and we
+	// exercise the ListStacks 404 path.
+	setTestTokenForHost(cfg, "gho_test_oauth_token")
 
 	cmd := SubmitCmd(cfg)
 	cmd.SetArgs([]string{"--auto"})
@@ -1706,4 +1714,89 @@ func TestSubmit_NoTemplate_UsesFooter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, capturedBody, "GitHub Stacks CLI", "footer should be present when no template")
 	assert.Contains(t, capturedBody, feedbackURL)
+}
+
+func TestSubmit_PreflightCheck_PAT_BailsOut(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1"},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	pushed := false
+	mock := newSubmitMock(tmpDir, "b1")
+	mock.PushFn = func(string, []string, bool, bool) error {
+		pushed = true
+		return nil
+	}
+	restore := git.SetOps(mock)
+	defer restore()
+
+	listStacksCalled := false
+	cfg, _, errR := config.NewTestConfig()
+	cfg.GitHubClientOverride = &github.MockClient{
+		ListStacksFn: func() ([]github.RemoteStack, error) {
+			listStacksCalled = true
+			return nil, nil
+		},
+	}
+
+	// Simulate a classic PAT — the pre-flight check should abort.
+	setTestTokenForHost(cfg, "ghp_classic_pat_token")
+
+	cmd := SubmitCmd(cfg)
+	cmd.SetArgs([]string{"--auto"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.ErrorIs(t, err, ErrStacksUnavailable)
+	assert.Contains(t, output, "Personal access tokens are not supported by gh stack")
+	assert.Contains(t, output, "gh auth login")
+	assert.False(t, pushed, "should not push when using a PAT")
+	assert.False(t, listStacksCalled, "should not call ListStacks when PAT detected")
+}
+
+func TestSubmit_PreflightCheck_FinegrainedPAT_BailsOut(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "b1"},
+			{Branch: "b2"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	mock := newSubmitMock(tmpDir, "b1")
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+	cfg.GitHubClientOverride = &github.MockClient{}
+
+	setTestTokenForHost(cfg, "github_pat_11AABBCC_xxxx")
+
+	cmd := SubmitCmd(cfg)
+	cmd.SetArgs([]string{"--auto"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.ErrorIs(t, err, ErrStacksUnavailable)
+	assert.Contains(t, output, "Personal access tokens are not supported by gh stack")
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -70,6 +70,16 @@ func printInterrupt(cfg *config.Config) {
 	cfg.Infof("Received interrupt, aborting operation")
 }
 
+// warnStacksUnavailableOrPAT prints an appropriate warning when a stacks API
+// call returns 404. If the token is a PAT the message focuses on the auth
+// issue; otherwise it falls back to the generic "not enabled" message.
+func warnStacksUnavailableOrPAT(cfg *config.Config) {
+	if cfg.WarnIfPAT() {
+		return
+	}
+	cfg.Warningf("Stacked PRs are not enabled for this repository")
+}
+
 // inputWithPrefill prompts the user for text input with the given prefill
 // already editable in the input field. Unlike survey.Input's Default (which
 // shows in parentheses), this places the prefill text directly in the

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/cli/go-gh/v2/pkg/repository"
 	"github.com/github/gh-stack/internal/config"
 	"github.com/github/gh-stack/internal/git"
 	"github.com/github/gh-stack/internal/github"
@@ -687,4 +689,39 @@ func TestStackNeedsRebase_SkipsMergedBranches(t *testing.T) {
 	defer restore()
 
 	assert.False(t, stackNeedsRebase(s), "should skip merged branches and find stack up to date")
+}
+
+// setTestTokenForHost sets cfg.TokenForHostFn to return the given token for
+// any host. Also sets RepoOverride so tests don't depend on real git context.
+func setTestTokenForHost(cfg *config.Config, token string) {
+	cfg.TokenForHostFn = func(string) (string, string) { return token, "test" }
+	cfg.RepoOverride = &repository.Repository{Host: "github.com", Owner: "o", Name: "r"}
+}
+
+func TestWarnStacksUnavailableOrPAT_ShowsPATMessage(t *testing.T) {
+	cfg, _, errR := config.NewTestConfig()
+	setTestTokenForHost(cfg, "github_pat_fine_grained")
+
+	warnStacksUnavailableOrPAT(cfg)
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.Contains(t, output, "Personal access tokens are not supported by gh stack")
+	assert.NotContains(t, output, "Stacked PRs are not enabled")
+}
+
+func TestWarnStacksUnavailableOrPAT_ShowsNotEnabledForOAuth(t *testing.T) {
+	cfg, _, errR := config.NewTestConfig()
+	setTestTokenForHost(cfg, "gho_oauth_token")
+
+	warnStacksUnavailableOrPAT(cfg)
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.Contains(t, output, "Stacked PRs are not enabled for this repository")
+	assert.NotContains(t, output, "Personal access tokens")
 }

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/cli/go-gh/v2/pkg/auth"
+)
+
+// tokenForHost returns the auth token for the given host, using the
+// test override if set or falling back to the real auth.TokenForHost.
+func (cfg *Config) tokenForHost(host string) (string, string) {
+	if cfg.TokenForHostFn != nil {
+		return cfg.TokenForHostFn(host)
+	}
+	return auth.TokenForHost(host)
+}
+
+// IsPersonalAccessToken reports whether the active token for the current
+// repository's host is a personal access token (classic or fine-grained)
+// rather than an OAuth token from `gh auth login`.
+//
+// Token prefix conventions:
+//
+//	gho_        → OAuth token (supported)
+//	ghs_        → GitHub App installation token (supported)
+//	ghp_        → Classic personal access token (NOT supported)
+//	github_pat_ → Fine-grained personal access token (NOT supported)
+func (cfg *Config) IsPersonalAccessToken() bool {
+	host := cfg.RepoHost()
+	if host == "" {
+		return false
+	}
+	return cfg.isPersonalAccessTokenForHost(host)
+}
+
+// isPersonalAccessTokenForHost checks the token prefix for the given host.
+func (cfg *Config) isPersonalAccessTokenForHost(host string) bool {
+	token, _ := cfg.tokenForHost(host)
+	if token == "" {
+		return false
+	}
+	return strings.HasPrefix(token, "ghp_") || strings.HasPrefix(token, "github_pat_")
+}
+
+// RepoHost returns the GitHub host for the current repository, or an empty
+// string if it cannot be determined (e.g. not inside a git repo).
+func (cfg *Config) RepoHost() string {
+	repo, err := cfg.Repo()
+	if err != nil {
+		return ""
+	}
+	return repo.Host
+}
+
+// WarnIfPAT checks whether the active token is a personal access token and,
+// if so, prints a warning explaining that PATs are not supported by gh stack.
+// Returns true when a PAT is detected.
+func (cfg *Config) WarnIfPAT() bool {
+	if !cfg.IsPersonalAccessToken() {
+		return false
+	}
+	cfg.Warningf("Personal access tokens are not supported by gh stack during private preview")
+	cfg.Printf("  Run %s to authenticate with OAuth instead.", cfg.ColorCyan("gh auth login"))
+	return true
+}

--- a/internal/config/auth_test.go
+++ b/internal/config/auth_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"io"
+	"testing"
+
+	"github.com/cli/go-gh/v2/pkg/repository"
+	"github.com/stretchr/testify/assert"
+)
+
+// testRepo is a fake repository used in tests to avoid depending on the
+// real git repo context (which may not exist in CI).
+var testRepo = &repository.Repository{Host: "github.com", Owner: "o", Name: "r"}
+
+func TestIsPersonalAccessToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{"oauth token", "gho_abc123", false},
+		{"app installation token", "ghs_abc123", false},
+		{"classic PAT", "ghp_abc123", true},
+		{"fine-grained PAT", "github_pat_abc123", true},
+		{"empty token", "", false},
+		{"unknown prefix", "some_other_token", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				TokenForHostFn: func(string) (string, string) { return tt.token, "test" },
+			}
+			got := cfg.isPersonalAccessTokenForHost("github.com")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWarnIfPAT_DetectsPAT(t *testing.T) {
+	cfg, _, errR := NewTestConfig()
+	cfg.RepoOverride = testRepo
+	cfg.TokenForHostFn = func(string) (string, string) { return "ghp_classic_pat_token", "test" }
+
+	result := cfg.WarnIfPAT()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.True(t, result)
+	assert.Contains(t, output, "Personal access tokens are not supported by gh stack")
+	assert.Contains(t, output, "gh auth login")
+}
+
+func TestWarnIfPAT_IgnoresOAuth(t *testing.T) {
+	cfg, _, errR := NewTestConfig()
+	cfg.RepoOverride = testRepo
+	cfg.TokenForHostFn = func(string) (string, string) { return "gho_oauth_token", "test" }
+
+	result := cfg.WarnIfPAT()
+
+	cfg.Err.Close()
+	errOut, _ := io.ReadAll(errR)
+	output := string(errOut)
+
+	assert.False(t, result)
+	assert.Empty(t, output)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,16 @@ type Config struct {
 	// InputFn, when non-nil, is called instead of prompting via the
 	// terminal. Used in tests to simulate text input prompts.
 	InputFn func(prompt, defaultValue string) (string, error)
+
+	// TokenForHostFn, when non-nil, is called instead of auth.TokenForHost
+	// to retrieve the auth token for a given GitHub host. Used in tests to
+	// simulate different token types (OAuth vs PAT).
+	TokenForHostFn func(host string) (string, string)
+
+	// RepoOverride, when non-nil, is returned by Repo() instead of
+	// calling repository.Current(). Used in tests to avoid depending on
+	// the real git repo context.
+	RepoOverride *repository.Repository
 }
 
 // New creates a new Config with terminal-aware output and color support.
@@ -126,6 +136,9 @@ func (c *Config) IsInteractive() bool {
 }
 
 func (c *Config) Repo() (repository.Repository, error) {
+	if c.RepoOverride != nil {
+		return *c.RepoOverride, nil
+	}
 	return repository.Current()
 }
 


### PR DESCRIPTION
When users authenticate the GitHub CLI with a personal access token (PAT) instead of OAuth (`gh auth login`), the `cli_internal` stacks API endpoints return 404. The CLI previously interpreted this as "Stacked PRs are not enabled for this repository," which is misleading — the feature may be enabled, but the token type simply cannot access the internal endpoints.

This is a recurring source of user confusion. The docs already note that PATs are not supported, but users don't always read them before hitting the error.

This change adds token-type detection by inspecting the `gh` auth token prefix:

  - `gho_`        → OAuth (supported)
  - `ghs_`        → GitHub App installation token (supported)
  - `ghp_`        → Classic PAT (NOT supported)
  - `github_pat_` → Fine-grained PAT (NOT supported)

When a PAT is detected, the CLI now shows:

  ⚠ Personal access tokens are not supported by gh stack
    Run `gh auth login` to authenticate with OAuth instead.

Instead of the misleading:

  ⚠ Stacked PRs are not enabled for this repository

Changes:

- Add `internal/config/auth.go` with auth detection methods on Config: `IsPersonalAccessToken()`, `WarnIfPAT()`, and `RepoHost()`. Uses a `TokenForHostFn` field on Config for test overrides, following the same pattern as `GitHubClientOverride`.

- Add a pre-flight PAT check in `cmd/submit.go` before the `ListStacks` call. If a PAT is detected, the command aborts early with a clear error instead of making a doomed API call.

- Update all 404 handlers for `cli_internal` endpoints to check the token type and show the appropriate message:
  - `cmd/submit.go` (createNewStack)
  - `cmd/link.go` (listStacksSafe, createLink)
  - `cmd/checkout.go` (checkoutRemoteStack)

- Add `warnStacksUnavailableOrPAT()` helper in `cmd/utils.go` that shows the PAT-specific warning when applicable, falling back to the generic "not enabled" message for non-PAT tokens.

- Add unit tests in `internal/config/auth_test.go` for token prefix detection and warning output.

- Add integration tests in `cmd/submit_test.go` verifying that both classic PATs (`ghp_`) and fine-grained PATs (`github_pat_`) trigger the pre-flight check and abort before any API calls.

- Add `warnStacksUnavailableOrPAT` tests in `cmd/utils_test.go` verifying correct message selection based on token type.

- Update existing 404 tests to explicitly set an OAuth token so they continue exercising the ListStacks 404 path.