### PR TITLE
Fully-qualify branch refspecs when pushing

### DIFF
--- a/internal/git/gitops.go
+++ b/internal/git/gitops.go
@@ -187,20 +187,14 @@ func (d *defaultOps) Push(remote string, branches []string, force, atomic bool) 
 	if atomic {
 		args = append(args, "--atomic")
 	}
-	if force {
-		// Fully-qualified refspecs: refs/heads/<local>:refs/heads/<remote>.
-		// Qualifying the source (not a bare branch name) ensures a branch
-		// name is never reinterpreted as refspec syntax — e.g. a leading
-		// "+" is part of the ref, not a force modifier. Force is supplied
-		// out-of-band by the --force-with-lease flags above.
-		for _, b := range branches {
-			args = append(args, fmt.Sprintf("refs/heads/%s:refs/heads/%s", b, b))
-		}
-	} else {
-		// Fully-qualified refspecs here too, for the same reason.
-		for _, b := range branches {
-			args = append(args, fmt.Sprintf("refs/heads/%s:refs/heads/%s", b, b))
-		}
+	// Fully-qualified refspecs: refs/heads/<local>:refs/heads/<remote>.
+	// Qualifying the source (not a bare branch name) ensures a branch name is
+	// never reinterpreted as refspec syntax — e.g. a leading "+" is part of the
+	// ref, not a force modifier. This form is identical whether or not the push
+	// is forced; force is supplied out-of-band by the --force-with-lease flags
+	// built above.
+	for _, b := range branches {
+		args = append(args, fmt.Sprintf("refs/heads/%s:refs/heads/%s", b, b))
 	}
 	return runSilent(args...)
 }

--- a/internal/git/gitops.go
+++ b/internal/git/gitops.go
@@ -188,12 +188,19 @@ func (d *defaultOps) Push(remote string, branches []string, force, atomic bool) 
 		args = append(args, "--atomic")
 	}
 	if force {
-		// Explicit refspecs: <local-branch>:refs/heads/<remote-branch>.
+		// Fully-qualified refspecs: refs/heads/<local>:refs/heads/<remote>.
+		// Qualifying the source (not a bare branch name) ensures a branch
+		// name is never reinterpreted as refspec syntax — e.g. a leading
+		// "+" is part of the ref, not a force modifier. Force is supplied
+		// out-of-band by the --force-with-lease flags above.
 		for _, b := range branches {
-			args = append(args, fmt.Sprintf("%s:refs/heads/%s", b, b))
+			args = append(args, fmt.Sprintf("refs/heads/%s:refs/heads/%s", b, b))
 		}
 	} else {
-		args = append(args, branches...)
+		// Fully-qualified refspecs here too, for the same reason.
+		for _, b := range branches {
+			args = append(args, fmt.Sprintf("refs/heads/%s:refs/heads/%s", b, b))
+		}
 	}
 	return runSilent(args...)
 }
@@ -544,7 +551,9 @@ func (d *defaultOps) DeleteBranch(name string, force bool) error {
 }
 
 func (d *defaultOps) DeleteRemoteBranch(remote, branch string) error {
-	return runSilent("push", remote, "--delete", branch)
+	// Fully-qualify the ref so a branch name is never reinterpreted as
+	// refspec syntax.
+	return runSilent("push", remote, "--delete", "refs/heads/"+branch)
 }
 
 func (d *defaultOps) DeleteTrackingRef(remote, branch string) error {

--- a/internal/git/gitops_test.go
+++ b/internal/git/gitops_test.go
@@ -361,6 +361,100 @@ func TestIntegration_Push_MixedStack(t *testing.T) {
 	assert.Equal(t, localB2, remoteBranchSHA(t, bareDir, "b2"))
 }
 
+// A stack branch whose name begins with "+" must push its own ref, not a
+// similarly named sibling. A leading "+" in a git refspec means "force update",
+// so passing a bare "+feature" (or "+feature:...") lets git treat it as a
+// refspec modifier for "feature". Fully-qualified refspecs keep the "+" part of
+// the branch name. Force path (used by push/submit).
+func TestIntegration_Push_PlusPrefixedBranch_Force(t *testing.T) {
+	bareDir, cloneDir := setupBareAndClone(t)
+	restore := withGitDir(t, cloneDir)
+	defer restore()
+
+	d := &defaultOps{}
+
+	// Create and push a normal "feature" branch (content A).
+	gitExec(t, cloneDir, "checkout", "-b", "feature")
+	writeFile(t, cloneDir, "feature.txt", "A")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "feature A")
+	gitExec(t, cloneDir, "push", "origin", "feature")
+	remoteFeatureBefore := remoteBranchSHA(t, bareDir, "feature")
+
+	// Create a local "+feature" branch off main with different content (B).
+	gitExec(t, cloneDir, "checkout", "main")
+	gitExec(t, cloneDir, "checkout", "-b", "+feature")
+	writeFile(t, cloneDir, "plus.txt", "B")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "plus B")
+	localPlus := gitExec(t, cloneDir, "rev-parse", "refs/heads/+feature")
+
+	// Advance local "feature" (content C) but do NOT push it. If the push
+	// followed refspec syntax, "+feature" would push this ref instead.
+	gitExec(t, cloneDir, "checkout", "feature")
+	writeFile(t, cloneDir, "feature.txt", "C")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "feature C")
+	localFeature := gitExec(t, cloneDir, "rev-parse", "refs/heads/feature")
+	require.NotEqual(t, localPlus, localFeature, "test setup: +feature and feature must differ")
+
+	// Push the "+feature" stack branch via the force path.
+	gitExec(t, cloneDir, "checkout", "+feature")
+	require.NoError(t, d.FetchBranches("origin", []string{"+feature"}))
+	require.NoError(t, d.Push("origin", []string{"+feature"}, true, false))
+
+	// Remote "+feature" must point at local "+feature" (B), and remote
+	// "feature" must be untouched (still A).
+	assert.Equal(t, localPlus, remoteBranchSHA(t, bareDir, "+feature"),
+		"remote +feature should hold the +feature commit, not feature's")
+	assert.Equal(t, remoteFeatureBefore, remoteBranchSHA(t, bareDir, "feature"),
+		"remote feature must not be force-updated")
+}
+
+// Same as above for the non-force, atomic path (used by link and by sync when
+// no rebase happened). A bare "+feature" operand would force-update remote
+// "feature"; a fully-qualified refspec creates remote "+feature" instead.
+func TestIntegration_Push_PlusPrefixedBranch_NonForce(t *testing.T) {
+	bareDir, cloneDir := setupBareAndClone(t)
+	restore := withGitDir(t, cloneDir)
+	defer restore()
+
+	d := &defaultOps{}
+
+	// Create and push a normal "feature" branch (content A).
+	gitExec(t, cloneDir, "checkout", "-b", "feature")
+	writeFile(t, cloneDir, "feature.txt", "A")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "feature A")
+	gitExec(t, cloneDir, "push", "origin", "feature")
+	remoteFeatureBefore := remoteBranchSHA(t, bareDir, "feature")
+
+	// Create a local "+feature" branch off main with different content (B).
+	gitExec(t, cloneDir, "checkout", "main")
+	gitExec(t, cloneDir, "checkout", "-b", "+feature")
+	writeFile(t, cloneDir, "plus.txt", "B")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "plus B")
+	localPlus := gitExec(t, cloneDir, "rev-parse", "refs/heads/+feature")
+
+	// Advance local "feature" (content C) but do NOT push it.
+	gitExec(t, cloneDir, "checkout", "feature")
+	writeFile(t, cloneDir, "feature.txt", "C")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "feature C")
+
+	// Push "+feature" via the non-force, atomic path.
+	gitExec(t, cloneDir, "checkout", "+feature")
+	require.NoError(t, d.Push("origin", []string{"+feature"}, false, true))
+
+	// Remote "+feature" must be created from local "+feature" (B), and remote
+	// "feature" must be untouched (still A).
+	assert.Equal(t, localPlus, remoteBranchSHA(t, bareDir, "+feature"),
+		"remote +feature should be created from the +feature commit")
+	assert.Equal(t, remoteFeatureBefore, remoteBranchSHA(t, bareDir, "feature"),
+		"remote feature must not be force-updated")
+}
+
 func TestSplitCommitMessage(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
`gh stack push`, `submit`, `sync`, and `link` push stack branches by passing their names to `git push`. Branch names were used as raw refspec operands: the force path built `<branch>:refs/heads/<branch>` and the non-force path passed bare branch names. A git refspec treats a leading `+` as "force update", and Git allows branch names that begin with `+`, so a branch named `+feature` was parsed as refspec syntax for `feature` — the force path pushed local `feature` into remote `+feature`, and the non-force path force-updated remote `feature`.

This builds fully-qualified refspecs for both the source and destination of every push, so a branch name can never be reinterpreted as a refspec modifier. It mirrors the fully-qualified form `gh pr create` uses.

## Behavior

- Every branch is pushed with an explicit `refs/heads/<branch>:refs/heads/<branch>` refspec; a leading `+` (or any other refspec-significant character) is treated as part of the branch name.
- Force updates are still requested through the existing `--force-with-lease` flags — their ref names were already fully-qualified — so the force / non-force behavior of `push`, `submit`, `sync`, and `link` is otherwise unchanged.

## Changes

`internal/git/gitops.go`:
- **`Push`** builds `refs/heads/<branch>:refs/heads/<branch>` refspecs in both the force and non-force paths, replacing the bare source (`<branch>:refs/heads/<branch>`) and the bare branch operands.
- **`DeleteRemoteBranch`** deletes `refs/heads/<branch>` rather than a bare branch name.
- `FetchBranches` already used fully-qualified refspecs and is unchanged.

The `Push` signature and every call site (`push` / `submit` / `sync` / `link`) are unchanged.

## Testing

`internal/git/gitops_test.go`:
- Adds real-git integration tests for the force and non-force paths that push a `+`-prefixed branch and assert the remote `+feature` ref receives the `+feature` commit while the sibling `feature` ref is left untouched.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>