### PR TITLE
Fix to properly revert after aborting modify

### DIFF
--- a/cmd/modify.go
+++ b/cmd/modify.go
@@ -219,8 +219,12 @@ func runModifyAbort(cfg *config.Config) error {
 	}
 
 	switch state.Phase {
-	case modify.PhaseApplying:
-		cfg.Printf("A modify session was interrupted during the apply phase")
+	case modify.PhaseApplying, modify.PhaseConflict:
+		if state.Phase == modify.PhaseConflict {
+			cfg.Printf("Aborting the modify and discarding in-progress conflict resolution")
+		} else {
+			cfg.Printf("A modify session was interrupted during the apply phase")
+		}
 		cfg.Printf("Restoring stack to pre-modify state...")
 		if err := modify.UnwindFromStateFile(cfg, gitDir); err != nil {
 			cfg.Errorf("recovery failed: %s", err)

--- a/cmd/modify_test.go
+++ b/cmd/modify_test.go
@@ -771,3 +771,132 @@ func TestCheckModifyStateGuard_UnknownPhase(t *testing.T) {
 	err := modify.CheckStateGuard(gitDir)
 	assert.NoError(t, err, "guard only blocks on 'applying' phase")
 }
+
+// ---------------------------------------------------------------------------
+// 6. runModifyAbort recovery
+// ---------------------------------------------------------------------------
+
+// Regression test: aborting a modify that stopped at a conflict must actually
+// unwind the stack (abort the in-flight rebase, reset branch tips to their
+// pre-modify SHAs, restore metadata, clear state) — not fall into a default
+// branch that merely deletes the state file and strands the user.
+func TestRunModifyAbort_ConflictPhase_Unwinds(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "A"},
+			{Branch: "B"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	writeStackFile(t, tmpDir, s)
+
+	meta, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	snapshot := modify.Snapshot{
+		Branches: []modify.BranchSnapshot{
+			{Name: "A", TipSHA: "sha-A-original", Position: 0},
+			{Name: "B", TipSHA: "sha-B-original", Position: 1},
+		},
+		StackMetadata: meta,
+	}
+
+	// The state ApplyPlan persists when a cascade rebase conflicts.
+	state := &modify.StateFile{
+		SchemaVersion:  1,
+		StackName:      "main",
+		StackIndex:     0,
+		Phase:          modify.PhaseConflict,
+		ConflictBranch: "B",
+		ConflictType:   "rebase",
+		Snapshot:       snapshot,
+	}
+	require.NoError(t, modify.SaveState(tmpDir, state))
+
+	var rebaseAborted bool
+	var resetCalls []struct{ branch, sha string }
+	current := ""
+	mock := &git.MockOps{
+		GitDirFn:                 func() (string, error) { return tmpDir, nil },
+		IsRebaseInProgressFn:     func() bool { return true },
+		IsCherryPickInProgressFn: func() bool { return false },
+		RebaseAbortFn:            func() error { rebaseAborted = true; return nil },
+		BranchExistsFn:           func(string) bool { return true },
+		CheckoutBranchFn:         func(name string) error { current = name; return nil },
+		ResetHardFn: func(sha string) error {
+			resetCalls = append(resetCalls, struct{ branch, sha string }{current, sha})
+			return nil
+		},
+		CreateBranchFn: func(string, string) error { return nil },
+	}
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+
+	err = runModifyAbort(cfg)
+
+	cfg.Out.Close()
+	cfg.Err.Close()
+	out, _ := io.ReadAll(errR)
+	output := string(out)
+
+	require.NoError(t, err)
+
+	// The in-flight rebase must have been aborted.
+	assert.True(t, rebaseAborted, "in-progress rebase should be aborted during recovery")
+
+	// The state file must be cleared because recovery ran (not left dangling,
+	// and not deleted-without-unwind).
+	assert.False(t, modify.StateExists(tmpDir), "state file should be cleared after a successful abort")
+
+	// Branch tips must be reset to their pre-modify snapshot SHAs.
+	resetMap := map[string]string{}
+	for _, r := range resetCalls {
+		resetMap[r.branch] = r.sha
+	}
+	assert.Equal(t, "sha-A-original", resetMap["A"])
+	assert.Equal(t, "sha-B-original", resetMap["B"])
+
+	// It must not fall into the old default branch.
+	assert.NotContains(t, output, "unexpected modify state phase")
+	assert.Contains(t, output, "Restoring stack to pre-modify state")
+}
+
+// PendingSubmit abort is a no-op that guides the user to submit; it must not
+// try to unwind (the local changes already succeeded).
+func TestRunModifyAbort_PendingSubmit_NoUnwind(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &modify.StateFile{
+		SchemaVersion: 1,
+		StackName:     "main",
+		StackIndex:    0,
+		Phase:         modify.PhasePendingSubmit,
+	}
+	require.NoError(t, modify.SaveState(tmpDir, state))
+
+	var resetCalled bool
+	mock := &git.MockOps{
+		GitDirFn:    func() (string, error) { return tmpDir, nil },
+		ResetHardFn: func(string) error { resetCalled = true; return nil },
+	}
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, errR := config.NewTestConfig()
+
+	err := runModifyAbort(cfg)
+
+	cfg.Out.Close()
+	cfg.Err.Close()
+	out, _ := io.ReadAll(errR)
+	output := string(out)
+
+	require.NoError(t, err)
+	assert.False(t, resetCalled, "pending-submit abort must not unwind branches")
+	assert.True(t, modify.StateExists(tmpDir), "pending-submit state should be preserved")
+	assert.Contains(t, output, "gh stack submit")
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -399,10 +399,23 @@ func CherryPick(commits []string) error {
 	return ops.CherryPick(commits)
 }
 
-// CherryPickAbort clears any in-progress cherry-pick state.
-// Errors are silently ignored (no-op if no cherry-pick is in progress).
-func CherryPickAbort() {
-	_ = ops.CherryPickAbort()
+// CherryPickQuit clears any in-progress cherry-pick sequencer state without
+// touching the working tree or index. Errors are silently ignored (no-op if no
+// cherry-pick is in progress).
+func CherryPickQuit() {
+	_ = ops.CherryPickQuit()
+}
+
+// CherryPickAbort cancels an in-progress cherry-pick, restoring the working
+// tree and index to the state before the cherry-pick began. Callers should
+// gate this with IsCherryPickInProgress, as it errors when none is in progress.
+func CherryPickAbort() error {
+	return ops.CherryPickAbort()
+}
+
+// IsCherryPickInProgress reports whether a cherry-pick is currently in progress.
+func IsCherryPickInProgress() bool {
+	return ops.IsCherryPickInProgress()
 }
 
 // CherryPickContinue continues an in-progress cherry-pick after conflicts are resolved.

--- a/internal/git/gitops.go
+++ b/internal/git/gitops.go
@@ -69,8 +69,10 @@ type Ops interface {
 	ValidateRefName(name string) error
 	RenameBranch(oldName, newName string) error
 	CherryPick(commits []string) error
+	CherryPickQuit() error
 	CherryPickAbort() error
 	CherryPickContinue() error
+	IsCherryPickInProgress() bool
 	HasUncommittedChanges() (bool, error)
 	LogMerges(base, head string) ([]CommitInfo, error)
 }
@@ -612,14 +614,38 @@ func (d *defaultOps) CherryPick(commits []string) error {
 	return runSilent(args...)
 }
 
-func (d *defaultOps) CherryPickAbort() error {
+// CherryPickQuit clears the in-progress cherry-pick sequencer state without
+// touching the working tree or index (git cherry-pick --quit). Used to clear
+// any stale sequencer state before starting a fresh cherry-pick.
+func (d *defaultOps) CherryPickQuit() error {
 	return runSilent("cherry-pick", "--quit")
+}
+
+// CherryPickAbort cancels an in-progress cherry-pick and restores the working
+// tree and index to the state before the cherry-pick began
+// (git cherry-pick --abort). Errors if no cherry-pick is in progress, so
+// callers should gate this with IsCherryPickInProgress.
+func (d *defaultOps) CherryPickAbort() error {
+	return runSilent("cherry-pick", "--abort")
 }
 
 func (d *defaultOps) CherryPickContinue() error {
 	cmd := exec.Command("git", "cherry-pick", "--continue")
 	cmd.Env = append(os.Environ(), "GIT_EDITOR=true")
 	return cmd.Run()
+}
+
+// IsCherryPickInProgress reports whether a cherry-pick is currently in progress
+// by checking for the CHERRY_PICK_HEAD marker in the git directory.
+func (d *defaultOps) IsCherryPickInProgress() bool {
+	gitDir, err := GitDir()
+	if err != nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(gitDir, "CHERRY_PICK_HEAD")); err == nil {
+		return true
+	}
+	return false
 }
 
 func (d *defaultOps) HasUncommittedChanges() (bool, error) {

--- a/internal/git/gitops_test.go
+++ b/internal/git/gitops_test.go
@@ -581,3 +581,89 @@ func TestIntegration_SaveAndGetRemote(t *testing.T) {
 	_, err = GetSavedRemote()
 	require.Error(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// Integration tests for cherry-pick in-progress detection and abort
+// ---------------------------------------------------------------------------
+
+// A conflicting cherry-pick must be detected as in-progress, and CherryPickAbort
+// must fully restore the working tree/index so branch checkouts succeed again.
+// This underpins modify's --abort recovery for fold-down (cherry-pick) conflicts.
+func TestIntegration_CherryPickInProgressAndAbort(t *testing.T) {
+	_, cloneDir := setupBareAndClone(t)
+	restore := withGitDir(t, cloneDir)
+	defer restore()
+
+	// Ensure runSilent-based git commands have a committer identity.
+	gitExec(t, cloneDir, "config", "user.name", "Test")
+	gitExec(t, cloneDir, "config", "user.email", "test@test.com")
+
+	// feature edits conflict.txt one way; main edits it another way.
+	gitExec(t, cloneDir, "checkout", "-b", "feature")
+	writeFile(t, cloneDir, "conflict.txt", "feature change\n")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "feature edit")
+	featureSHA := gitExec(t, cloneDir, "rev-parse", "feature")
+
+	gitExec(t, cloneDir, "checkout", "main")
+	writeFile(t, cloneDir, "conflict.txt", "main change\n")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "main edit")
+
+	// No cherry-pick in progress before we start.
+	assert.False(t, IsCherryPickInProgress(), "no cherry-pick should be in progress initially")
+
+	// Cherry-picking feature onto main conflicts.
+	err := CherryPick([]string{featureSHA})
+	require.Error(t, err, "cherry-pick should conflict")
+	assert.True(t, IsCherryPickInProgress(), "cherry-pick should be in progress after a conflict")
+
+	// While mid-conflict, a plain checkout must fail (unmerged index).
+	_, coErr := gitExecMayFail(t, cloneDir, "checkout", "feature")
+	require.Error(t, coErr, "checkout should fail while cherry-pick index is unmerged")
+
+	// Aborting must fully restore: no longer in progress, clean tree, checkout works.
+	require.NoError(t, CherryPickAbort())
+	assert.False(t, IsCherryPickInProgress(), "cherry-pick should not be in progress after abort")
+
+	status, err := gitExecMayFail(t, cloneDir, "status", "--porcelain")
+	require.NoError(t, err)
+	assert.Empty(t, status, "working tree should be clean after abort")
+
+	_, coErr = gitExecMayFail(t, cloneDir, "checkout", "feature")
+	require.NoError(t, coErr, "checkout should succeed after abort restores a clean index")
+}
+
+// CherryPickQuit clears the sequencer state but intentionally leaves the index
+// as-is, so a plain checkout still fails. This documents why Unwind uses the
+// full --abort rather than --quit.
+func TestIntegration_CherryPickQuitLeavesIndexUnmerged(t *testing.T) {
+	_, cloneDir := setupBareAndClone(t)
+	restore := withGitDir(t, cloneDir)
+	defer restore()
+
+	gitExec(t, cloneDir, "config", "user.name", "Test")
+	gitExec(t, cloneDir, "config", "user.email", "test@test.com")
+
+	gitExec(t, cloneDir, "checkout", "-b", "feature")
+	writeFile(t, cloneDir, "conflict.txt", "feature change\n")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "feature edit")
+	featureSHA := gitExec(t, cloneDir, "rev-parse", "feature")
+
+	gitExec(t, cloneDir, "checkout", "main")
+	writeFile(t, cloneDir, "conflict.txt", "main change\n")
+	gitExec(t, cloneDir, "add", ".")
+	gitExec(t, cloneDir, "commit", "-m", "main edit")
+
+	require.Error(t, CherryPick([]string{featureSHA}))
+	require.True(t, IsCherryPickInProgress())
+
+	// --quit clears sequencer state (no longer "in progress") ...
+	CherryPickQuit()
+	assert.False(t, IsCherryPickInProgress(), "quit should clear cherry-pick sequencer state")
+
+	// ... but leaves the unmerged index behind, so checkout still fails.
+	_, coErr := gitExecMayFail(t, cloneDir, "checkout", "feature")
+	require.Error(t, coErr, "checkout should still fail after --quit because the index is unmerged")
+}

--- a/internal/git/mock_ops.go
+++ b/internal/git/mock_ops.go
@@ -6,56 +6,60 @@ import "fmt"
 // Each field is an optional function that, when set, handles the corresponding
 // Ops method call. When nil, a reasonable default is returned.
 type MockOps struct {
-	GitDirFn                func() (string, error)
-	RootDirFn               func() (string, error)
-	CurrentBranchFn         func() (string, error)
-	BranchExistsFn          func(string) bool
-	CheckoutBranchFn        func(string) error
-	FetchFn                 func(string) error
-	FetchBranchesFn         func(string, []string) error
-	DefaultBranchFn         func() (string, error)
-	CreateBranchFn          func(string, string) error
-	PushFn                  func(string, []string, bool, bool) error
-	ResolveRemoteFn         func(string) (string, error)
-	RebaseFn                func(string, RebaseOpts) error
-	EnableRerereFn          func() error
-	IsRerereEnabledFn       func() (bool, error)
-	IsRerereDeclinedFn      func() (bool, error)
-	SaveRerereDeclinedFn    func() error
-	GetSavedRemoteFn        func() (string, error)
-	SaveRemoteFn            func(string) error
-	ClearRemoteFn           func() error
-	RebaseOntoFn            func(string, string, string, RebaseOpts) error
-	RebaseContinueFn        func(RebaseOpts) error
-	RebaseAbortFn           func() error
-	IsRebaseInProgressFn    func() bool
-	ConflictedFilesFn       func() ([]string, error)
-	FindConflictMarkersFn   func(string) (*ConflictMarkerInfo, error)
-	IsAncestorFn            func(string, string) (bool, error)
-	RevParseFn              func(string) (string, error)
-	RevParseMultiFn         func([]string) ([]string, error)
-	MergeBaseFn             func(string, string) (string, error)
-	LogFn                   func(string, int) ([]CommitInfo, error)
-	LogRangeFn              func(string, string) ([]CommitInfo, error)
-	DiffStatRangeFn         func(string, string) (int, int, error)
-	DiffStatFilesFn         func(string, string) ([]FileDiffStat, error)
-	DeleteBranchFn          func(string, bool) error
-	DeleteRemoteBranchFn    func(string, string) error
-	DeleteTrackingRefFn     func(string, string) error
-	ResetHardFn             func(string) error
-	SetUpstreamTrackingFn   func(string, string) error
-	MergeFFFn               func(string) error
-	UpdateBranchRefFn       func(string, string) error
-	StageAllFn              func() error
-	StageTrackedFn          func() error
-	HasStagedChangesFn      func() bool
-	CommitFn                func(string) (string, error)
-	CommitInteractiveFn     func() (string, error)
-	ValidateRefNameFn       func(string) error
-	RenameBranchFn          func(string, string) error
-	CherryPickFn            func([]string) error
-	HasUncommittedChangesFn func() (bool, error)
-	LogMergesFn             func(string, string) ([]CommitInfo, error)
+	GitDirFn                 func() (string, error)
+	RootDirFn                func() (string, error)
+	CurrentBranchFn          func() (string, error)
+	BranchExistsFn           func(string) bool
+	CheckoutBranchFn         func(string) error
+	FetchFn                  func(string) error
+	FetchBranchesFn          func(string, []string) error
+	DefaultBranchFn          func() (string, error)
+	CreateBranchFn           func(string, string) error
+	PushFn                   func(string, []string, bool, bool) error
+	ResolveRemoteFn          func(string) (string, error)
+	RebaseFn                 func(string, RebaseOpts) error
+	EnableRerereFn           func() error
+	IsRerereEnabledFn        func() (bool, error)
+	IsRerereDeclinedFn       func() (bool, error)
+	SaveRerereDeclinedFn     func() error
+	GetSavedRemoteFn         func() (string, error)
+	SaveRemoteFn             func(string) error
+	ClearRemoteFn            func() error
+	RebaseOntoFn             func(string, string, string, RebaseOpts) error
+	RebaseContinueFn         func(RebaseOpts) error
+	RebaseAbortFn            func() error
+	IsRebaseInProgressFn     func() bool
+	ConflictedFilesFn        func() ([]string, error)
+	FindConflictMarkersFn    func(string) (*ConflictMarkerInfo, error)
+	IsAncestorFn             func(string, string) (bool, error)
+	RevParseFn               func(string) (string, error)
+	RevParseMultiFn          func([]string) ([]string, error)
+	MergeBaseFn              func(string, string) (string, error)
+	LogFn                    func(string, int) ([]CommitInfo, error)
+	LogRangeFn               func(string, string) ([]CommitInfo, error)
+	DiffStatRangeFn          func(string, string) (int, int, error)
+	DiffStatFilesFn          func(string, string) ([]FileDiffStat, error)
+	DeleteBranchFn           func(string, bool) error
+	DeleteRemoteBranchFn     func(string, string) error
+	DeleteTrackingRefFn      func(string, string) error
+	ResetHardFn              func(string) error
+	SetUpstreamTrackingFn    func(string, string) error
+	MergeFFFn                func(string) error
+	UpdateBranchRefFn        func(string, string) error
+	StageAllFn               func() error
+	StageTrackedFn           func() error
+	HasStagedChangesFn       func() bool
+	CommitFn                 func(string) (string, error)
+	CommitInteractiveFn      func() (string, error)
+	ValidateRefNameFn        func(string) error
+	RenameBranchFn           func(string, string) error
+	CherryPickFn             func([]string) error
+	CherryPickQuitFn         func() error
+	CherryPickAbortFn        func() error
+	CherryPickContinueFn     func() error
+	IsCherryPickInProgressFn func() bool
+	HasUncommittedChangesFn  func() (bool, error)
+	LogMergesFn              func(string, string) ([]CommitInfo, error)
 }
 
 var _ Ops = (*MockOps)(nil)
@@ -405,11 +409,31 @@ func (m *MockOps) CherryPick(commits []string) error {
 	return nil
 }
 
-func (m *MockOps) CherryPickAbort() error {
+func (m *MockOps) CherryPickQuit() error {
+	if m.CherryPickQuitFn != nil {
+		return m.CherryPickQuitFn()
+	}
 	return nil
 }
 
+func (m *MockOps) CherryPickAbort() error {
+	if m.CherryPickAbortFn != nil {
+		return m.CherryPickAbortFn()
+	}
+	return nil
+}
+
+func (m *MockOps) IsCherryPickInProgress() bool {
+	if m.IsCherryPickInProgressFn != nil {
+		return m.IsCherryPickInProgressFn()
+	}
+	return false
+}
+
 func (m *MockOps) CherryPickContinue() error {
+	if m.CherryPickContinueFn != nil {
+		return m.CherryPickContinueFn()
+	}
 	return nil
 }
 

--- a/internal/modify/apply.go
+++ b/internal/modify/apply.go
@@ -916,6 +916,16 @@ func ContinueApply(
 			state.AffectsPRs = affectsPRs
 			_ = SaveState(gitDir, state)
 
+			// Persist the stack metadata so far. A fold-down removes the
+			// folded branch from the in-memory stack (above) before the
+			// cascade rebase runs. If we don't save it here, the next
+			// --continue re-reads the on-disk metadata (folded branch still
+			// present) and — because ConflictType is now "rebase" — skips the
+			// fold-removal block, silently resurrecting the folded branch as a
+			// phantom entry. Mirrors ApplyPlan's save-on-conflict.
+			if saveErr := stack.SaveWithLock(gitDir, sf, lock); saveErr != nil {
+				cfg.Warningf("failed to save stack metadata: %v", saveErr)
+			}
 			cfg.Warningf("Conflict rebasing %s", branchName)
 			if files, ferr := git.ConflictedFiles(); ferr == nil {
 				for _, f := range files {

--- a/internal/modify/apply.go
+++ b/internal/modify/apply.go
@@ -397,7 +397,7 @@ func ApplyPlan(
 					shas[len(commits)-1-i] = c.SHA
 				}
 
-				git.CherryPickAbort()
+				git.CherryPickQuit()
 
 				if err := git.CherryPick(shas); err != nil {
 					conflict := &modifyview.ConflictInfo{Branch: foldBranch}
@@ -906,6 +906,12 @@ func ContinueApply(
 				}
 			}
 			state.ConflictBranch = branchName
+			// These remaining branches are always rebased via RebaseOnto, so
+			// the in-progress operation is a rebase. Update ConflictType in
+			// case the original conflict was a cherry-pick (fold-down) — a
+			// stale "cherry_pick" here would make the next --continue call
+			// CherryPickContinue and fail.
+			state.ConflictType = "rebase"
 			state.RemainingBranches = remaining
 			state.AffectsPRs = affectsPRs
 			_ = SaveState(gitDir, state)
@@ -977,9 +983,15 @@ func ContinueApply(
 // Unwind restores the stack to its pre-modify state using the snapshot.
 // stackIndex is the index of the stack in sf.Stacks at modify start time.
 func Unwind(cfg *config.Config, gitDir string, snapshot Snapshot, stackIndex int, sf *stack.StackFile, plan []Action) error {
-	// Abort any in-progress rebase
+	// Abort any in-progress rebase or cherry-pick so the working tree and
+	// index are clean before we restore branch tips. A fold-down conflict
+	// leaves an in-progress cherry-pick with an unmerged index; without
+	// aborting it first, the restore checkouts below would fail.
 	if git.IsRebaseInProgress() {
 		_ = git.RebaseAbort()
+	}
+	if git.IsCherryPickInProgress() {
+		_ = git.CherryPickAbort()
 	}
 
 	// Restore branch tips

--- a/internal/modify/apply_test.go
+++ b/internal/modify/apply_test.go
@@ -1329,6 +1329,94 @@ func TestContinueApply_SubsequentConflictBecomesRebase(t *testing.T) {
 	assert.Equal(t, "C", got.ConflictBranch)
 }
 
+// Regression test for the review on PR #167: after an initial fold-down
+// (cherry-pick) conflict is resolved, a subsequent cascade rebase conflict must
+// persist the fold-branch removal to disk. Otherwise the next --continue
+// re-reads stale on-disk metadata and — because ConflictType is now "rebase" —
+// skips the fold-removal step, silently resurrecting the folded branch as a
+// phantom entry once recovery completes.
+func TestContinueApply_FoldThenCascadeConflict_DoesNotResurrectFoldedBranch(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "A"},
+			{Branch: "B"},
+			{Branch: "C"},
+		},
+	}
+
+	gitDir := t.TempDir()
+	writeTestStackFile(t, gitDir, s)
+
+	// State written by ApplyPlan when the fold-down of B into A conflicts on
+	// cherry-pick. B is still present in the on-disk metadata at this point.
+	state := &StateFile{
+		SchemaVersion:     1,
+		StackName:         "main",
+		StackIndex:        0,
+		Phase:             PhaseConflict,
+		ConflictType:      "cherry_pick",
+		ConflictBranch:    "B",
+		FoldBranch:        "B",
+		FoldTarget:        "A",
+		RemainingBranches: []string{"A", "C"},
+		OriginalBranch:    "A",
+		OriginalRefs:      map[string]string{"A": "sha-main", "C": "sha-A-old"},
+	}
+	require.NoError(t, SaveState(gitDir, state))
+
+	mock := newApplyMock(gitDir, map[string]string{
+		"main": "sha-main", "A": "sha-A", "B": "sha-B", "C": "sha-C",
+	})
+	mock.CherryPickContinueFn = func() error { return nil }
+	mock.IsRebaseInProgressFn = func() bool { return true }
+	mock.RebaseContinueFn = func(git.RebaseOpts) error { return nil }
+	// C conflicts on its first rebase attempt, then succeeds (user resolved it).
+	cRebases := 0
+	mock.RebaseOntoFn = func(newBase, oldBase, branch string, opts git.RebaseOpts) error {
+		if branch == "C" {
+			cRebases++
+			if cRebases == 1 {
+				return assert.AnError
+			}
+		}
+		return nil
+	}
+	mock.ConflictedFilesFn = func() ([]string, error) { return []string{"c.go"}, nil }
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, _ := config.NewTestConfig()
+	defer cfg.Out.Close()
+	defer cfg.Err.Close()
+
+	// First --continue: finishes the fold, then conflicts rebasing C.
+	err := ContinueApply(cfg, gitDir, noopUpdateBaseSHAs)
+	require.Error(t, err)
+
+	// The fold-branch removal must already be persisted on disk, even though
+	// the cascade hit a conflict.
+	afterFirst, err := stack.Load(gitDir)
+	require.NoError(t, err)
+	assert.Equal(t, -1, afterFirst.Stacks[0].IndexOf("B"),
+		"folded branch B must not be present on disk after the cascade conflict")
+
+	// Second --continue: rebase resolves and recovery completes.
+	err = ContinueApply(cfg, gitDir, noopUpdateBaseSHAs)
+	require.NoError(t, err)
+
+	final, err := stack.Load(gitDir)
+	require.NoError(t, err)
+	names := make([]string, len(final.Stacks[0].Branches))
+	for i, b := range final.Stacks[0].Branches {
+		names[i] = b.Branch
+	}
+	assert.Equal(t, []string{"A", "C"}, names,
+		"folded branch B must stay removed after recovery completes")
+	assert.False(t, StateExists(gitDir), "state should be cleared after successful recovery")
+}
+
 // ─── Unwind restores renamed branch ─────────────────────────────────────────
 
 func TestUnwind_RestoresRenamedBranch(t *testing.T) {

--- a/internal/modify/apply_test.go
+++ b/internal/modify/apply_test.go
@@ -51,7 +51,7 @@ func newApplyMock(gitDir string, branchSHAs map[string]string) *git.MockOps {
 			}
 			return "sha-" + ref, nil
 		},
-		IsAncestorFn:        func(a, d string) (bool, error) { return false, nil },
+		IsAncestorFn:         func(a, d string) (bool, error) { return false, nil },
 		MergeBaseFn:          func(a, b string) (string, error) { return "merge-base", nil },
 		CheckoutBranchFn:     func(string) error { return nil },
 		RebaseOntoFn:         func(string, string, string, git.RebaseOpts) error { return nil },
@@ -60,11 +60,11 @@ func newApplyMock(gitDir string, branchSHAs map[string]string) *git.MockOps {
 		LogRangeFn: func(base, head string) ([]git.CommitInfo, error) {
 			return []git.CommitInfo{{SHA: "commit-1"}, {SHA: "commit-2"}}, nil
 		},
-		CherryPickFn:    func([]string) error { return nil },
+		CherryPickFn:      func([]string) error { return nil },
 		ConflictedFilesFn: func() ([]string, error) { return nil, nil },
-		ResetHardFn:     func(string) error { return nil },
-		CreateBranchFn:  func(string, string) error { return nil },
-		RebaseAbortFn:   func() error { return nil },
+		ResetHardFn:       func(string) error { return nil },
+		CreateBranchFn:    func(string, string) error { return nil },
+		RebaseAbortFn:     func() error { return nil },
 	}
 }
 
@@ -795,14 +795,14 @@ func TestContinueApply_MultiStackFindsCorrectStack(t *testing.T) {
 
 	// Create a state file pointing at Stack 1 (index 1)
 	state := &StateFile{
-		SchemaVersion:   1,
-		StackName:       "main",
-		StackIndex:      1, // The correct stack is at index 1
-		Phase:           PhaseConflict,
-		ConflictBranch:  "A",
-		ConflictType:    "rebase",
+		SchemaVersion:     1,
+		StackName:         "main",
+		StackIndex:        1, // The correct stack is at index 1
+		Phase:             PhaseConflict,
+		ConflictBranch:    "A",
+		ConflictType:      "rebase",
 		RemainingBranches: []string{"B", "C"},
-		OriginalRefs:    map[string]string{"B": "sha-A", "C": "sha-B"},
+		OriginalRefs:      map[string]string{"B": "sha-A", "C": "sha-B"},
 	}
 	require.NoError(t, SaveState(gitDir, state))
 
@@ -1044,13 +1044,13 @@ func TestContinueApply(t *testing.T) {
 
 	// Write a conflict state file
 	stateFile := &StateFile{
-		SchemaVersion:      1,
-		StackName:          "main",
-		StackIndex:         0,
-		Phase:              "conflict",
-		ConflictBranch:     "B",
-		RemainingBranches:  []string{"C"},
-		OriginalBranch:     "A",
+		SchemaVersion:     1,
+		StackName:         "main",
+		StackIndex:        0,
+		Phase:             "conflict",
+		ConflictBranch:    "B",
+		RemainingBranches: []string{"C"},
+		OriginalBranch:    "A",
 		OriginalRefs: map[string]string{
 			"A": "sha-A",
 			"B": "sha-B",
@@ -1064,9 +1064,9 @@ func TestContinueApply(t *testing.T) {
 	var checkoutCalls []string
 
 	mock := &git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		CurrentBranchFn: func() (string, error) { return "B", nil },
-		BranchExistsFn:  func(string) bool { return true },
+		GitDirFn:             func() (string, error) { return gitDir, nil },
+		CurrentBranchFn:      func() (string, error) { return "B", nil },
+		BranchExistsFn:       func(string) bool { return true },
 		IsRebaseInProgressFn: func() bool { return true },
 		RebaseContinueFn: func(git.RebaseOpts) error {
 			rebaseContinueCalled = true
@@ -1081,8 +1081,8 @@ func TestContinueApply(t *testing.T) {
 			return nil
 		},
 		IsAncestorFn: func(a, d string) (bool, error) { return false, nil },
-		MergeBaseFn:   func(a, b string) (string, error) { return "merge-base", nil },
-		RevParseFn:    func(ref string) (string, error) { return "sha-" + ref, nil },
+		MergeBaseFn:  func(a, b string) (string, error) { return "merge-base", nil },
+		RevParseFn:   func(ref string) (string, error) { return "sha-" + ref, nil },
 	}
 
 	restore := git.SetOps(mock)
@@ -1201,6 +1201,132 @@ func TestUnwind_AbortsActiveRebase(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, rebaseAbortCalled, "RebaseAbort should be called when rebase is in progress")
 	assert.False(t, StateExists(gitDir))
+}
+
+// ─── Unwind with active cherry-pick ─────────────────────────────────────────
+
+// A fold-down conflict leaves an in-progress cherry-pick with an unmerged
+// index. Unwind must abort it (git cherry-pick --abort) before restoring
+// branches, otherwise the restore checkouts fail on the unmerged index.
+func TestUnwind_AbortsActiveCherryPick(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "A"},
+		},
+	}
+
+	gitDir := t.TempDir()
+	sf := writeTestStackFile(t, gitDir, s)
+
+	snapshotMock := &git.MockOps{
+		RevParseFn: func(ref string) (string, error) { return "sha-" + ref, nil },
+	}
+	restore := git.SetOps(snapshotMock)
+	snapshot, err := BuildSnapshot(&s)
+	require.NoError(t, err)
+	restore()
+
+	require.NoError(t, SaveState(gitDir, &StateFile{
+		SchemaVersion: 1, Phase: PhaseConflict, ConflictType: "cherry_pick", Snapshot: snapshot,
+	}))
+
+	var cherryPickAbortCalled bool
+	var rebaseAbortCalled bool
+	mock := &git.MockOps{
+		IsRebaseInProgressFn:     func() bool { return false },
+		IsCherryPickInProgressFn: func() bool { return true },
+		RebaseAbortFn:            func() error { rebaseAbortCalled = true; return nil },
+		CherryPickAbortFn:        func() error { cherryPickAbortCalled = true; return nil },
+		BranchExistsFn:           func(string) bool { return true },
+		CheckoutBranchFn:         func(string) error { return nil },
+		ResetHardFn:              func(string) error { return nil },
+		CreateBranchFn:           func(string, string) error { return nil },
+	}
+
+	restore = git.SetOps(mock)
+	defer restore()
+
+	cfg, _, _ := config.NewTestConfig()
+	defer cfg.Out.Close()
+	defer cfg.Err.Close()
+
+	err = Unwind(cfg, gitDir, snapshot, 0, sf, nil)
+	require.NoError(t, err)
+	assert.True(t, cherryPickAbortCalled, "CherryPickAbort should be called when a cherry-pick is in progress")
+	assert.False(t, rebaseAbortCalled, "RebaseAbort should not be called when no rebase is in progress")
+	assert.False(t, StateExists(gitDir))
+}
+
+// ─── ContinueApply: subsequent conflict after fold-down is a rebase ─────────
+
+// After resolving an initial fold-down (cherry-pick) conflict, the cascading
+// rebase over the remaining branches may itself conflict. That conflict is a
+// rebase, so ContinueApply must update ConflictType from "cherry_pick" to
+// "rebase" — otherwise the next --continue wrongly calls CherryPickContinue
+// and fails, stranding the user.
+func TestContinueApply_SubsequentConflictBecomesRebase(t *testing.T) {
+	s := stack.Stack{
+		Trunk: stack.BranchRef{Branch: "main"},
+		Branches: []stack.BranchRef{
+			{Branch: "A"},
+			{Branch: "B"},
+			{Branch: "C"},
+		},
+	}
+
+	gitDir := t.TempDir()
+	sf := writeTestStackFile(t, gitDir, s)
+	_ = sf
+
+	// State as written when a fold-down of B into A conflicts on cherry-pick.
+	// B is still present in the stack metadata (it is removed only after the
+	// cherry-pick succeeds in ContinueApply).
+	state := &StateFile{
+		SchemaVersion:     1,
+		StackName:         "main",
+		StackIndex:        0,
+		Phase:             PhaseConflict,
+		ConflictType:      "cherry_pick",
+		ConflictBranch:    "B",
+		FoldBranch:        "B",
+		FoldTarget:        "A",
+		RemainingBranches: []string{"A", "C"},
+		OriginalBranch:    "A",
+		OriginalRefs:      map[string]string{"A": "sha-main", "C": "sha-A-old"},
+	}
+	require.NoError(t, SaveState(gitDir, state))
+
+	mock := newApplyMock(gitDir, map[string]string{
+		"main": "sha-main", "A": "sha-A", "B": "sha-B", "C": "sha-C",
+	})
+	// The user resolved the cherry-pick; --continue finishes it cleanly.
+	mock.CherryPickContinueFn = func() error { return nil }
+	// A rebases cleanly onto main; C then conflicts.
+	mock.RebaseOntoFn = func(newBase, oldBase, branch string, opts git.RebaseOpts) error {
+		if branch == "C" {
+			return assert.AnError
+		}
+		return nil
+	}
+	mock.ConflictedFilesFn = func() ([]string, error) { return []string{"c.go"}, nil }
+
+	restore := git.SetOps(mock)
+	defer restore()
+
+	cfg, _, _ := config.NewTestConfig()
+	defer cfg.Out.Close()
+	defer cfg.Err.Close()
+
+	err := ContinueApply(cfg, gitDir, noopUpdateBaseSHAs)
+	require.Error(t, err)
+
+	got, loadErr := LoadState(gitDir)
+	require.NoError(t, loadErr)
+	require.NotNil(t, got)
+	assert.Equal(t, PhaseConflict, got.Phase)
+	assert.Equal(t, "rebase", got.ConflictType, "subsequent cascade conflict must be recorded as a rebase")
+	assert.Equal(t, "C", got.ConflictBranch)
 }
 
 // ─── Unwind restores renamed branch ─────────────────────────────────────────


### PR DESCRIPTION
Fix `gh stack modify --abort` leaving the stack in a broken state after a conflict

## Summary

When `gh stack modify` runs into a rebase or cherry-pick conflict, it stops and tells the user they can restore their stack with `gh stack modify --abort`. Following that advice did not actually restore anything. The abort deleted the modify state file without unwinding, so the in-progress rebase or cherry-pick stayed active, branches were left partially rewritten, and — because the state file was gone — `gh stack modify --continue` no longer worked either. The stack was stuck in a broken, unrecoverable state.

This PR makes `--abort` from a conflict do what it promises, and fixes two related recovery gaps found along the way.

## Root cause

`runModifyAbort` switched on the saved modify phase but had no case for the `conflict` phase. It handled `applying` (unwind) and `pending_submit` (guide to submit), and everything else — including `conflict` — fell into the `default` branch, which printed "unexpected modify state phase" and deleted the state file without restoring the stack.

## What this changes

- **Abort now recovers from a conflict.** `runModifyAbort` treats the `conflict` phase the same as `applying`: it aborts the in-progress git operation, resets every branch tip back to its pre-modify SHA, restores the stack metadata, and clears the state file.
- **Unwind aborts an in-progress cherry-pick, not just a rebase.** Fold-down operations use a cherry-pick, and a conflicted cherry-pick leaves an unmerged index. Without aborting it first, the restore checkouts would fail. `git cherry-pick --quit` (what the abort previously ran) only clears the sequencer state and leaves the index unmerged; a full `git cherry-pick --abort` is required to get back to a clean tree.
- **A follow-on conflict is recorded as a rebase.** After resolving an initial fold-down conflict, the remaining branches are replayed with a cascading rebase. If one of those conflicts, the saved conflict type is now updated from `cherry_pick` to `rebase`, so the next `--continue` resumes the rebase instead of failing while trying to continue a cherry-pick that is no longer in progress.

To support the above, the git layer gains `IsCherryPickInProgress()` and splits the old cherry-pick reset into `CherryPickQuit()` (`--quit`, used to clear stale state before starting a fold) and `CherryPickAbort()` (`--abort`, used for recovery).

## Not affected

`gh stack rebase --abort`, `gh stack sync`, and `gh stack submit` were checked and do not share this problem. Rebase restores refs on abort, sync auto-aborts and restores on conflict because it is non-interactive, and submit does not rebase or cherry-pick.

## Testing

- `go vet ./...` is clean and the full `go test -race -count=1 ./...` suite passes.
- New coverage: aborting from the conflict phase actually unwinds (verified to fail against the old behavior), the pending-submit abort stays a no-op, `Unwind` aborts an active cherry-pick, and the cherry-pick to rebase conflict-type transition.
- New git integration tests cover cherry-pick in-progress detection, the full `--abort` restore, and the fact that `--quit` intentionally leaves the index unmerged.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>