### PR TITLE
Deprecate branch name prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ internal/
     schema.json              # JSON Schema for the stack file format
   config/                    # Config struct (I/O, colors, test overrides)
     testing.go               # NewTestConfig(). Returns *Config + stdout/stderr pipes.
-  branch/                    # branch naming (Slugify, DateSlug, NextNumberedName)
+  branch/                    # branch naming (Slugify, DateSlug)
   modify/                    # interactive stack modification state machine
   pr/                        # PR template discovery
   tui/                       # bubbletea/bubbles/lipgloss terminal UI

--- a/README.md
+++ b/README.md
@@ -76,19 +76,15 @@ Initialize a new stack in the current repository.
 gh stack init [flags] [branches...]
 ```
 
-Initializes a new stack locally. In interactive mode (no arguments), prompts for a branch name and offers to use the current branch as the first layer. If a branch name contains slashes (e.g., `feat/api`), prompts if you would like to use a prefix (e.g., `feat/`) for all branches in the stack.
+Initializes a new stack locally. In interactive mode (no arguments), prompts for a branch name and offers to use the current branch as the first layer.
 
 When explicit branch names are given, existing branches are adopted automatically and any missing branches are created. The trunk defaults to the repository's default branch unless overridden with `--base`.
-
-Use `--numbered` with `--prefix` to enable auto-incrementing numbered branch names (`prefix/01`, `prefix/02`, …). Without `--numbered`, you'll always be prompted to provide a meaningful branch name.
 
 Enables `git rerere` automatically so that conflict resolutions are remembered across rebases.
 
 | Flag | Description |
 |------|-------------|
 | `-b, --base <branch>` | Trunk branch for the stack (defaults to the repository's default branch) |
-| `-p, --prefix <string>` | Set a branch name prefix for the stack |
-| `-n, --numbered` | Use auto-incrementing numbered branch names (requires `--prefix`) |
 
 **Examples:**
 
@@ -104,15 +100,6 @@ gh stack init --base develop feature-auth
 
 # Adopt existing branches into a stack
 gh stack init feature-auth feature-api
-
-# Set a prefix — you'll be prompted for a branch name
-gh stack init -p feat
-#    → prompts "Enter a name for the first branch (will be prefixed with feat/)"
-#    → type "auth" → creates feat/auth
-
-# Use numbered auto-incrementing branch names
-gh stack init -p feat --numbered
-#    → creates feat/01 automatically
 ```
 
 ### `gh stack add`
@@ -125,7 +112,7 @@ gh stack add [flags] [branch]
 
 Creates a new branch at the current HEAD, adds it to the top of the stack, and checks it out. Must be run while on the topmost branch of a stack. If no branch name is given, prompts for one.
 
-You can optionally stage changes and create a commit as part of the `add` flow. When `-m` is provided without an explicit branch name, the branch name is auto-generated. If the stack was created with `--numbered`, auto-generated names use numbered format (`prefix/01`, `prefix/02`); otherwise, date+slug format is used (e.g., `prefix/2025-03-24-add-login`).
+You can optionally stage changes and create a commit as part of the `add` flow. When `-m` is provided without an explicit branch name, the branch name is auto-generated in date+slug format (e.g., `03-24-add_login`).
 
 | Flag | Description |
 |------|-------------|
@@ -616,21 +603,21 @@ gh stack sync
 
 ## Abbreviated workflow
 
-If you want to minimize keystrokes, use a branch prefix with `--numbered` and the `-Am` flags to fold staging, committing, and branch creation into a single command. Branch names are auto-generated as `prefix/01`, `prefix/02`, etc.
+If you want to minimize keystrokes, use the `-Am` flags to fold staging, committing, and branch creation into a single command. When you don't pass a branch name, one is auto-generated from the commit message in date+slug format (e.g., `03-24-auth_middleware`).
 
 When a branch has no commits yet (e.g., right after `init`), `add -Am` stages and commits directly on that branch instead of creating a new one. Once a branch has commits, `add -Am` creates a new branch, checks it out, and commits there.
 
 ```sh
-# 1. Start a stack with a prefix and numbered branches
-gh stack init -p feat --numbered
-#    → creates feat/01 and checks it out
+# 1. Start a stack
+gh stack init auth
+#    → creates auth and checks it out
 
 # 2. Write code for the first layer
 #    ... write code ...
 
 # 3. Stage and commit on the current branch
 gh stack add -Am "Auth middleware"
-#    → feat/01 has no commits yet, so the commit lands here
+#    → auth has no commits yet, so the commit lands here
 #      (no new branch is created)
 
 # 4. Write code for the next layer
@@ -638,20 +625,20 @@ gh stack add -Am "Auth middleware"
 
 # 5. Create the next branch and commit
 gh stack add -Am "API routes"
-#    → feat/01 already has commits, so a new branch feat/02 is
-#      created, checked out, and the commit lands there
+#    → auth already has commits, so a new branch is created from the
+#      commit message, checked out, and the commit lands there
 
 # 6. Keep going
 #    ... write code ...
 
 gh stack add -Am "Frontend components"
-#    → feat/02 already has commits, creates feat/03 and commits there
+#    → creates another branch and commits there
 
 # 7. Push everything and create PRs
 gh stack submit
 ```
 
-Compared to the typical workflow, there's no need to name branches, run `git add`, or run `git commit` separately. Each `gh stack add -Am "..."` does it all.
+Compared to the typical workflow, there's no need to name branches, run `git add`, or run `git commit` separately. Each `gh stack add -Am "..."` does it all. Pass an explicit branch name any time you want to control it: `gh stack add -Am "API routes" api-routes`.
 
 ## Terminal theme
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -27,8 +27,7 @@ func AddCmd(cfg *config.Config) *cobra.Command {
 
 When -m is omitted but -A or -u is used, your editor opens for the
 commit message. When -m is provided without an explicit branch name,
-the branch name is auto-generated based on the commit message and
-stack prefix.`,
+the branch name is auto-generated from the commit message.`,
 		Example: `  # Add a new named branch to the stack
   $ gh stack add my-feature
 
@@ -119,55 +118,41 @@ func runAdd(cfg *config.Config, opts *addOptions, args []string) error {
 		return nil
 	}
 
-	// Resolve branch name
+	// Resolve branch name:
+	//   explicit name    -> used verbatim
+	//   -m without a name -> auto-generated from the commit message
+	//   neither          -> prompt for a name
 	var branchName string
 	var explicitName string
 	if len(args) > 0 {
 		explicitName = args[0]
 	}
-	existingBranches := s.BranchNames()
 
-	if opts.message != "" {
-		// Auto-naming mode
-		name, info := branch.ResolveBranchName(s.Prefix, opts.message, explicitName, existingBranches, s.Numbered)
-		if name == "" {
+	if explicitName != "" {
+		branchName = explicitName
+	} else if opts.message != "" {
+		branchName = branch.DateSlug(opts.message)
+		if branchName == "" {
 			cfg.Errorf("could not generate branch name")
 			return ErrSilent
 		}
-		branchName = name
-		if info != "" {
-			cfg.Infof("%s", info)
-		}
-	} else if explicitName != "" {
-		branchName = applyPrefix(cfg, s.Prefix, explicitName)
 	} else {
-		// No -m, no explicit name — auto-generate if using numbered
-		// convention, otherwise prompt for a name.
-		if s.Numbered && s.Prefix != "" {
-			branchName = branch.NextNumberedName(s.Prefix, existingBranches)
-		} else {
-			// Pre-fill the prompt with the prefix so the user can see
-			// (and optionally edit) the full branch name.
-			prefill := ""
-			if s.Prefix != "" {
-				prefill = s.Prefix + "/"
-			}
-			for {
-				input, err := inputWithPrefill(cfg, "Enter a name for the new branch:", prefill)
-				if err != nil {
-					if isInterruptError(err) {
-						printInterrupt(cfg)
-						return ErrSilent
-					}
-					return fmt.Errorf("could not read branch name: %w", err)
+		// No -m and no explicit name — prompt for one.
+		for {
+			input, err := promptInput(cfg, "Enter a name for the new branch:")
+			if err != nil {
+				if isInterruptError(err) {
+					printInterrupt(cfg)
+					return ErrSilent
 				}
-				if input == "" {
-					cfg.Warningf("branch name cannot be empty, please try again")
-					continue
-				}
-				branchName = input
-				break
+				return fmt.Errorf("could not read branch name: %w", err)
 			}
+			if input == "" {
+				cfg.Warningf("branch name cannot be empty, please try again")
+				continue
+			}
+			branchName = input
+			break
 		}
 	}
 
@@ -280,13 +265,4 @@ func doCommit(message string) (string, error) {
 		return git.Commit(message)
 	}
 	return git.CommitInteractive()
-}
-
-// applyPrefix prepends the stack prefix to a branch name if set.
-func applyPrefix(cfg *config.Config, prefix, name string) string {
-	if prefix != "" {
-		name = prefix + "/" + name
-		cfg.Infof("Branch name prefixed: %s", name)
-	}
-	return name
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/github/gh-stack/internal/config"
 	"github.com/github/gh-stack/internal/git"
@@ -212,18 +213,17 @@ func TestAdd_BranchWithCommitsCreatesNew(t *testing.T) {
 	assert.True(t, commitCalled, "expected Commit to be called on the new branch")
 }
 
-func TestAdd_PrefixAppliedWithSlash(t *testing.T) {
+func TestAdd_ExplicitNameUsedVerbatim(t *testing.T) {
 	gitDir := t.TempDir()
 	saveStack(t, gitDir, stack.Stack{
-		Prefix:   "feat",
 		Trunk:    stack.BranchRef{Branch: "main"},
-		Branches: []stack.BranchRef{{Branch: "feat/01"}},
+		Branches: []stack.BranchRef{{Branch: "b1"}},
 	})
 
 	var createdBranch string
 	restore := git.SetOps(&git.MockOps{
 		GitDirFn:        func() (string, error) { return gitDir, nil },
-		CurrentBranchFn: func() (string, error) { return "feat/01", nil },
+		CurrentBranchFn: func() (string, error) { return "b1", nil },
 		CreateBranchFn: func(name, base string) error {
 			createdBranch = name
 			return nil
@@ -236,22 +236,20 @@ func TestAdd_PrefixAppliedWithSlash(t *testing.T) {
 	output := collectOutput(cfg, outR, errR)
 
 	require.NotContains(t, output, "\u2717", "unexpected error")
-	assert.Equal(t, "feat/mybranch", createdBranch)
+	assert.Equal(t, "mybranch", createdBranch)
 }
 
-func TestAdd_NumberedNaming(t *testing.T) {
+func TestAdd_MessageAutoGeneratesDateSlug(t *testing.T) {
 	gitDir := t.TempDir()
 	saveStack(t, gitDir, stack.Stack{
-		Prefix:   "feat",
-		Numbered: true,
 		Trunk:    stack.BranchRef{Branch: "main"},
-		Branches: []stack.BranchRef{{Branch: "feat/01"}},
+		Branches: []stack.BranchRef{{Branch: "b1"}},
 	})
 
 	var createdBranch string
 	restore := git.SetOps(&git.MockOps{
 		GitDirFn:        func() (string, error) { return gitDir, nil },
-		CurrentBranchFn: func() (string, error) { return "feat/01", nil },
+		CurrentBranchFn: func() (string, error) { return "b1", nil },
 		RevParseMultiFn: func(refs []string) ([]string, error) {
 			return []string{"aaa", "bbb"}, nil
 		},
@@ -271,7 +269,8 @@ func TestAdd_NumberedNaming(t *testing.T) {
 	output := collectOutput(cfg, outR, errR)
 
 	require.NotContains(t, output, "\u2717", "unexpected error")
-	assert.Equal(t, "feat/02", createdBranch)
+	today := time.Now().Format("2006-01-02")
+	assert.Equal(t, today+"-next-feature", createdBranch)
 }
 
 func TestAdd_FullyMergedStackBlocked(t *testing.T) {
@@ -322,47 +321,7 @@ func TestAdd_NothingToCommit(t *testing.T) {
 	assert.Contains(t, output, "no changes to commit")
 }
 
-func TestAdd_PromptPrefillsPrefix(t *testing.T) {
-	gitDir := t.TempDir()
-	saveStack(t, gitDir, stack.Stack{
-		Prefix:   "feat",
-		Trunk:    stack.BranchRef{Branch: "main"},
-		Branches: []stack.BranchRef{{Branch: "feat/01"}},
-	})
-
-	var createdBranch string
-	restore := git.SetOps(&git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		CurrentBranchFn: func() (string, error) { return "feat/01", nil },
-		CreateBranchFn: func(name, base string) error {
-			createdBranch = name
-			return nil
-		},
-		CheckoutBranchFn: func(name string) error { return nil },
-		RevParseFn:       func(ref string) (string, error) { return "abc", nil },
-	})
-	defer restore()
-
-	cfg, outR, errR := config.NewTestConfig()
-
-	var gotPrompt, gotDefault string
-	cfg.InputFn = func(prompt, defaultValue string) (string, error) {
-		gotPrompt = prompt
-		gotDefault = defaultValue
-		return "feat/my-branch", nil
-	}
-
-	err := runAdd(cfg, &addOptions{}, nil)
-	output := collectOutput(cfg, outR, errR)
-
-	require.NoError(t, err)
-	require.NotContains(t, output, "\u2717", "unexpected error")
-	assert.Contains(t, gotPrompt, ":", "prompt should end with a colon")
-	assert.Equal(t, "feat/", gotDefault, "prompt should pre-fill prefix/")
-	assert.Equal(t, "feat/my-branch", createdBranch, "full input should be used as branch name")
-}
-
-func TestAdd_PromptNoPrefixEmptyDefault(t *testing.T) {
+func TestAdd_PromptForBranchName(t *testing.T) {
 	gitDir := t.TempDir()
 	saveStack(t, gitDir, stack.Stack{
 		Trunk:    stack.BranchRef{Branch: "main"},
@@ -384,9 +343,9 @@ func TestAdd_PromptNoPrefixEmptyDefault(t *testing.T) {
 
 	cfg, outR, errR := config.NewTestConfig()
 
-	var gotDefault string
-	cfg.InputFn = func(prompt, defaultValue string) (string, error) {
-		gotDefault = defaultValue
+	var gotPrompt string
+	cfg.InputFn = func(prompt string) (string, error) {
+		gotPrompt = prompt
 		return "my-branch", nil
 	}
 
@@ -395,22 +354,21 @@ func TestAdd_PromptNoPrefixEmptyDefault(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotContains(t, output, "\u2717", "unexpected error")
-	assert.Equal(t, "", gotDefault, "prompt should have empty default when no prefix")
+	assert.Contains(t, gotPrompt, ":", "prompt should end with a colon")
 	assert.Equal(t, "my-branch", createdBranch, "input should be used as-is")
 }
 
-func TestAdd_PromptUserModifiesPrefix(t *testing.T) {
+func TestAdd_PromptInputUsedVerbatim(t *testing.T) {
 	gitDir := t.TempDir()
 	saveStack(t, gitDir, stack.Stack{
-		Prefix:   "feat",
 		Trunk:    stack.BranchRef{Branch: "main"},
-		Branches: []stack.BranchRef{{Branch: "feat/01"}},
+		Branches: []stack.BranchRef{{Branch: "b1"}},
 	})
 
 	var createdBranch string
 	restore := git.SetOps(&git.MockOps{
 		GitDirFn:        func() (string, error) { return gitDir, nil },
-		CurrentBranchFn: func() (string, error) { return "feat/01", nil },
+		CurrentBranchFn: func() (string, error) { return "b1", nil },
 		CreateBranchFn: func(name, base string) error {
 			createdBranch = name
 			return nil
@@ -422,8 +380,7 @@ func TestAdd_PromptUserModifiesPrefix(t *testing.T) {
 
 	cfg, outR, errR := config.NewTestConfig()
 
-	cfg.InputFn = func(prompt, defaultValue string) (string, error) {
-		// Simulate user changing the prefix entirely
+	cfg.InputFn = func(prompt string) (string, error) {
 		return "custom/other-name", nil
 	}
 
@@ -432,7 +389,7 @@ func TestAdd_PromptUserModifiesPrefix(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotContains(t, output, "\u2717", "unexpected error")
-	assert.Equal(t, "custom/other-name", createdBranch, "user-modified input should be used verbatim")
+	assert.Equal(t, "custom/other-name", createdBranch, "typed input should be used verbatim")
 }
 
 func TestAdd_FromTrunk(t *testing.T) {

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -269,8 +269,8 @@ func TestAdd_MessageAutoGeneratesDateSlug(t *testing.T) {
 	output := collectOutput(cfg, outR, errR)
 
 	require.NotContains(t, output, "\u2717", "unexpected error")
-	today := time.Now().Format("2006-01-02")
-	assert.Equal(t, today+"-next-feature", createdBranch)
+	today := time.Now().Format("01-02")
+	assert.Equal(t, today+"-next_feature", createdBranch)
 }
 
 func TestAdd_FullyMergedStackBlocked(t *testing.T) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/prompter"
-	"github.com/github/gh-stack/internal/branch"
 	"github.com/github/gh-stack/internal/config"
 	"github.com/github/gh-stack/internal/git"
 	"github.com/github/gh-stack/internal/stack"
@@ -16,8 +15,6 @@ import (
 type initOptions struct {
 	branches []string
 	base     string
-	prefix   string
-	numbered bool
 	adopt    bool // deprecated, kept for backward compat
 }
 
@@ -44,9 +41,6 @@ Use --base to specify a different trunk branch.`,
   # Adopt existing branches into a stack (bottom to top)
   $ gh stack init feat/auth feat/api feat/ui
 
-  # Create a stack with auto-numbered branches (feat/01, feat/02, etc.)
-  $ gh stack init --prefix feat --numbered
-
   # Specify a different trunk branch
   $ gh stack init --base develop my-feature`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -56,8 +50,6 @@ Use --base to specify a different trunk branch.`,
 	}
 
 	cmd.Flags().StringVarP(&opts.base, "base", "b", "", "Trunk branch for stack (defaults to default branch)")
-	cmd.Flags().StringVarP(&opts.prefix, "prefix", "p", "", "Branch name prefix for the stack")
-	cmd.Flags().BoolVarP(&opts.numbered, "numbered", "n", false, "Use auto-incrementing numbered branch names (requires --prefix)")
 	cmd.Flags().BoolVarP(&opts.adopt, "adopt", "a", false, "Deprecated: existing branches are now adopted automatically")
 	_ = cmd.Flags().MarkHidden("adopt")
 
@@ -123,20 +115,6 @@ func runInit(cfg *config.Config, opts *initOptions) error {
 			cfg.ColorCyan("gh stack init <branch1> <branch2> ..."))
 	}
 
-	// --numbered requires a prefix (either from flag or interactive input).
-	if opts.numbered && opts.prefix == "" && !cfg.IsInteractive() {
-		cfg.Errorf("--numbered requires --prefix")
-		return ErrInvalidArgs
-	}
-
-	// Validate explicit --prefix before branch creation.
-	if opts.prefix != "" {
-		if err := git.ValidateRefName(opts.prefix); err != nil {
-			cfg.Errorf("invalid prefix %q: must be a valid git ref component", opts.prefix)
-			return ErrInvalidArgs
-		}
-	}
-
 	// --- Branch collection ---
 
 	var branches []string
@@ -149,39 +127,6 @@ func runInit(cfg *config.Config, opts *initOptions) error {
 			return err
 		}
 
-	} else if opts.numbered {
-		// === NUMBERED PATH (unchanged) ===
-		if opts.prefix == "" && cfg.IsInteractive() {
-			prefixInput, err := inputWithPrefill(cfg, "Enter a branch prefix (required for --numbered):", "")
-			if err != nil {
-				if isInterruptError(err) {
-					printInterrupt(cfg)
-					return ErrSilent
-				}
-				cfg.Errorf("failed to read prefix: %s", err)
-				return ErrSilent
-			}
-			opts.prefix = strings.TrimSpace(prefixInput)
-			if opts.prefix == "" {
-				cfg.Errorf("--numbered requires a prefix")
-				return ErrInvalidArgs
-			}
-		}
-		branchName := branch.NextNumberedName(opts.prefix, nil)
-		if err := sf.ValidateNoDuplicateBranch(branchName); err != nil {
-			cfg.Errorf("branch %q already exists in a stack", branchName)
-			return ErrInvalidArgs
-		}
-		if git.BranchExists(branchName) {
-			adopted[branchName] = true
-		} else {
-			if err := git.CreateBranch(branchName, trunk); err != nil {
-				cfg.Errorf("creating branch %s: %s", branchName, err)
-				return ErrSilent
-			}
-		}
-		branches = []string{branchName}
-
 	} else {
 		// === INTERACTIVE PATH ===
 		if !cfg.IsInteractive() {
@@ -190,7 +135,7 @@ func runInit(cfg *config.Config, opts *initOptions) error {
 		}
 
 		var interactiveAdopted bool
-		branches, interactiveAdopted, err = runInteractiveInit(cfg, sf, trunk, currentBranch, opts)
+		branches, interactiveAdopted, err = runInteractiveInit(cfg, sf, trunk, currentBranch)
 		if err != nil {
 			return err
 		}
@@ -213,8 +158,6 @@ func runInit(cfg *config.Config, opts *initOptions) error {
 	}
 
 	newStack := stack.Stack{
-		Prefix:   opts.prefix,
-		Numbered: opts.numbered,
 		Trunk: stack.BranchRef{
 			Branch: trunk,
 			Head:   trunkSHA,
@@ -279,11 +222,6 @@ func resolveArgBranches(cfg *config.Config, opts *initOptions, sf *stack.StackFi
 	resolved := make([]branchInfo, 0, len(opts.branches))
 
 	for _, b := range opts.branches {
-		// Apply explicit --prefix (not detected prefix)
-		if opts.prefix != "" {
-			b = opts.prefix + "/" + b
-		}
-
 		// Validate ref name before checking existence or creating
 		if err := git.ValidateRefName(b); err != nil {
 			cfg.Errorf("invalid branch name %q: must be a valid git ref", b)
@@ -322,10 +260,10 @@ func resolveArgBranches(cfg *config.Config, opts *initOptions, sf *stack.StackFi
 }
 
 // runInteractiveInit runs the interactive init flow: prints hint about
-// multi-branch args, offers current branch or new branch, then runs
-// prefix detection. Returns the branches and whether the branch was adopted
-// (already existed).
-func runInteractiveInit(cfg *config.Config, sf *stack.StackFile, trunk, currentBranch string, opts *initOptions) ([]string, bool, error) {
+// multi-branch args, then offers to use the current branch or create a new
+// one. Returns the branches and whether the branch was adopted (already
+// existed).
+func runInteractiveInit(cfg *config.Config, sf *stack.StackFile, trunk, currentBranch string) ([]string, bool, error) {
 	p := prompter.New(cfg.In, cfg.Out, cfg.Err)
 
 	cfg.Printf("Initializing a stack from %s.", trunk)
@@ -369,7 +307,7 @@ func runInteractiveInit(cfg *config.Config, sf *stack.StackFile, trunk, currentB
 			branchName = currentBranch
 		} else {
 			// Create a new branch — fall through to input prompt
-			name, err := promptBranchName(cfg, opts.prefix)
+			name, err := promptBranchName(cfg)
 			if err != nil {
 				return nil, false, err
 			}
@@ -377,7 +315,7 @@ func runInteractiveInit(cfg *config.Config, sf *stack.StackFile, trunk, currentB
 		}
 	} else {
 		// On trunk or detached HEAD — prompt for name directly
-		name, err := promptBranchName(cfg, opts.prefix)
+		name, err := promptBranchName(cfg)
 		if err != nil {
 			return nil, false, err
 		}
@@ -399,39 +337,12 @@ func runInteractiveInit(cfg *config.Config, sf *stack.StackFile, trunk, currentB
 		}
 	}
 
-	// Prefix detection (interactive path, no --prefix flag)
-	if opts.prefix == "" {
-		if lastSlash := strings.LastIndex(branchName, "/"); lastSlash > 0 {
-			detected := branchName[:lastSlash]
-			usePrefix, err := p.Confirm(
-				fmt.Sprintf("Use %q as a prefix for new branches in this stack?", detected+"/"),
-				true,
-			)
-			if err != nil {
-				if isInterruptError(err) {
-					printInterrupt(cfg)
-					return nil, false, ErrSilent
-				}
-				// Not fatal — just skip prefix
-			} else if usePrefix {
-				opts.prefix = detected
-			}
-		}
-	}
-
 	return []string{branchName}, wasAdopted, nil
 }
 
-// promptBranchName prompts the user for a branch name, pre-filling the
-// prefix in the input when set so the user can see and edit the full name.
-func promptBranchName(cfg *config.Config, prefix string) (string, error) {
-	prefill := ""
-	prompt := "What's the name of the first branch:"
-	if prefix != "" {
-		prompt = "Enter a name for the first branch:"
-		prefill = prefix + "/"
-	}
-	branchName, err := inputWithPrefill(cfg, prompt, prefill)
+// promptBranchName prompts the user for the name of the first branch.
+func promptBranchName(cfg *config.Config) (string, error) {
+	branchName, err := promptInput(cfg, "What's the name of the first branch:")
 	if err != nil {
 		if isInterruptError(err) {
 			printInterrupt(cfg)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -94,25 +94,7 @@ func TestInit_AdoptExistingBranches(t *testing.T) {
 	assert.Equal(t, []string{"b1", "b2", "b3"}, names)
 }
 
-func TestInit_PrefixStoredInStack(t *testing.T) {
-	gitDir := t.TempDir()
-	restore := git.SetOps(&git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		DefaultBranchFn: func() (string, error) { return "main", nil },
-		CurrentBranchFn: func() (string, error) { return "main", nil },
-	})
-	defer restore()
-
-	cfg, outR, errR := config.NewTestConfig()
-	runInit(cfg, &initOptions{branches: []string{"myBranch"}, prefix: "feat"})
-	collectOutput(cfg, outR, errR)
-
-	sf, err := stack.Load(gitDir)
-	require.NoError(t, err, "loading stack")
-	assert.Equal(t, "feat", sf.Stacks[0].Prefix)
-}
-
-func TestInit_PrefixAppliedToExplicitBranches(t *testing.T) {
+func TestInit_ExplicitBranchNamesUsedVerbatim(t *testing.T) {
 	gitDir := t.TempDir()
 	var created []string
 	restore := git.SetOps(&git.MockOps{
@@ -127,43 +109,16 @@ func TestInit_PrefixAppliedToExplicitBranches(t *testing.T) {
 	defer restore()
 
 	cfg, outR, errR := config.NewTestConfig()
-	err := runInit(cfg, &initOptions{branches: []string{"b1", "b2"}, prefix: "feat"})
+	err := runInit(cfg, &initOptions{branches: []string{"feat/a", "feat/b"}})
 	output := collectOutput(cfg, outR, errR)
 
 	require.NoError(t, err, "runInit should succeed")
 	require.NotContains(t, output, "\u2717", "unexpected error")
-	assert.Equal(t, []string{"feat/b1", "feat/b2"}, created, "branches should be created with prefix")
+	assert.Equal(t, []string{"feat/a", "feat/b"}, created, "branches should be created verbatim")
 
 	sf, err := stack.Load(gitDir)
 	require.NoError(t, err, "loading stack")
-	names := sf.Stacks[0].BranchNames()
-	assert.Equal(t, []string{"feat/b1", "feat/b2"}, names, "stack should store prefixed branch names")
-}
-
-func TestInit_InvalidPrefixRejectedBeforeBranchCreation(t *testing.T) {
-	gitDir := t.TempDir()
-	var created []string
-	restore := git.SetOps(&git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		DefaultBranchFn: func() (string, error) { return "main", nil },
-		CurrentBranchFn: func() (string, error) { return "main", nil },
-		ValidateRefNameFn: func(name string) error {
-			return fmt.Errorf("invalid ref name: %s", name)
-		},
-		CreateBranchFn: func(name, base string) error {
-			created = append(created, name)
-			return nil
-		},
-	})
-	defer restore()
-
-	cfg, outR, errR := config.NewTestConfig()
-	err := runInit(cfg, &initOptions{branches: []string{"mybranch"}, prefix: "bad..prefix"})
-	output := collectOutput(cfg, outR, errR)
-
-	assert.ErrorIs(t, err, ErrInvalidArgs, "should reject invalid prefix")
-	assert.Contains(t, output, "invalid prefix")
-	assert.Empty(t, created, "no branches should be created when prefix is invalid")
+	assert.Equal(t, []string{"feat/a", "feat/b"}, sf.Stacks[0].BranchNames(), "stack should store branch names verbatim")
 }
 
 func TestInit_AdoptFlagShowsDeprecationWarning(t *testing.T) {
@@ -464,110 +419,6 @@ func TestInit_ImplicitAdopt_Mixed(t *testing.T) {
 	assert.Equal(t, []string{"existing1", "new1", "existing2"}, sf.Stacks[0].BranchNames())
 }
 
-func TestInit_PrefixDetection_ArgsCommonPrefix(t *testing.T) {
-	// Explicit branch names with a common prefix should NOT auto-detect
-	// a prefix — the slash is part of the branch name, not a convention.
-	// Users who want a prefix should use --prefix.
-	gitDir := t.TempDir()
-	restore := git.SetOps(&git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		DefaultBranchFn: func() (string, error) { return "main", nil },
-		CurrentBranchFn: func() (string, error) { return "main", nil },
-		CreateBranchFn:  func(name, base string) error { return nil },
-	})
-	defer restore()
-
-	cfg, outR, errR := config.NewTestConfig()
-	err := runInit(cfg, &initOptions{branches: []string{"feat/a", "feat/b", "feat/c"}})
-	collectOutput(cfg, outR, errR)
-
-	require.NoError(t, err)
-	sf, _ := stack.Load(gitDir)
-	assert.Equal(t, "", sf.Stacks[0].Prefix)
-}
-
-func TestInit_PrefixDetection_ArgsMixedPrefix(t *testing.T) {
-	// Scenario 10: args mixed prefixes → no prefix
-	gitDir := t.TempDir()
-	restore := git.SetOps(&git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		DefaultBranchFn: func() (string, error) { return "main", nil },
-		CurrentBranchFn: func() (string, error) { return "main", nil },
-		CreateBranchFn:  func(name, base string) error { return nil },
-	})
-	defer restore()
-
-	cfg, outR, errR := config.NewTestConfig()
-	err := runInit(cfg, &initOptions{branches: []string{"feat/a", "bug/b"}})
-	collectOutput(cfg, outR, errR)
-
-	require.NoError(t, err)
-	sf, _ := stack.Load(gitDir)
-	assert.Equal(t, "", sf.Stacks[0].Prefix)
-}
-
-func TestInit_PrefixDetection_ArgsNoSlash(t *testing.T) {
-	// No slashes → no prefix
-	gitDir := t.TempDir()
-	restore := git.SetOps(&git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		DefaultBranchFn: func() (string, error) { return "main", nil },
-		CurrentBranchFn: func() (string, error) { return "main", nil },
-		CreateBranchFn:  func(name, base string) error { return nil },
-	})
-	defer restore()
-
-	cfg, outR, errR := config.NewTestConfig()
-	err := runInit(cfg, &initOptions{branches: []string{"auth", "api", "ui"}})
-	collectOutput(cfg, outR, errR)
-
-	require.NoError(t, err)
-	sf, _ := stack.Load(gitDir)
-	assert.Equal(t, "", sf.Stacks[0].Prefix)
-}
-
-func TestInit_PrefixDetection_NestedPrefix(t *testing.T) {
-	// Explicit branch names with nested slashes should NOT auto-detect
-	// a prefix — the user typed the full branch name deliberately.
-	gitDir := t.TempDir()
-	restore := git.SetOps(&git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		DefaultBranchFn: func() (string, error) { return "main", nil },
-		CurrentBranchFn: func() (string, error) { return "main", nil },
-		CreateBranchFn:  func(name, base string) error { return nil },
-	})
-	defer restore()
-
-	cfg, outR, errR := config.NewTestConfig()
-	err := runInit(cfg, &initOptions{branches: []string{"sameen/feat/a", "sameen/feat/b"}})
-	collectOutput(cfg, outR, errR)
-
-	require.NoError(t, err)
-	sf, _ := stack.Load(gitDir)
-	assert.Equal(t, "", sf.Stacks[0].Prefix)
-}
-
-func TestInit_ExplicitPrefixSkipsDetection(t *testing.T) {
-	// Scenario 14: --prefix with args → explicit wins
-	gitDir := t.TempDir()
-	restore := git.SetOps(&git.MockOps{
-		GitDirFn:        func() (string, error) { return gitDir, nil },
-		DefaultBranchFn: func() (string, error) { return "main", nil },
-		CurrentBranchFn: func() (string, error) { return "main", nil },
-		CreateBranchFn:  func(name, base string) error { return nil },
-	})
-	defer restore()
-
-	cfg, outR, errR := config.NewTestConfig()
-	err := runInit(cfg, &initOptions{branches: []string{"b1", "b2"}, prefix: "foo"})
-	collectOutput(cfg, outR, errR)
-
-	require.NoError(t, err)
-	sf, _ := stack.Load(gitDir)
-	assert.Equal(t, "foo", sf.Stacks[0].Prefix)
-	assert.Equal(t, []string{"foo/b1", "foo/b2"}, sf.Stacks[0].BranchNames())
-}
-
 func TestInit_WhatsNext_Fresh(t *testing.T) {
 	// Scenario 17: fresh single-branch → fresh format
 	gitDir := t.TempDir()
@@ -730,8 +581,6 @@ func TestInit_Interactive_OnFeatureBranch_UseCurrent(t *testing.T) {
 	sf, _ := stack.Load(gitDir)
 	require.Len(t, sf.Stacks, 1)
 	assert.Equal(t, []string{"feat/auth"}, sf.Stacks[0].BranchNames())
-	// Prefix detection Y/n prompt fails gracefully without a TTY,
-	// so prefix is not set. The args-path prefix detection is tested separately.
 }
 
 func TestInit_TwoPassValidation_NoBranchCreatedOnError(t *testing.T) {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -548,11 +548,9 @@ func maybeForkFromMergedBase(cfg *config.Config, client github.ClientOps, sf *st
 		return s // nothing new to fork — the whole stack is merged and done
 	}
 
-	// Capture trunk/prefix before mutating sf.Stacks (RemoveStack/AddStack can
+	// Capture trunk before mutating sf.Stacks (RemoveStack/AddStack can
 	// reallocate the slice and invalidate the s pointer).
 	trunk := s.Trunk
-	prefix := s.Prefix
-	numbered := s.Numbered
 
 	// The bottom surviving branch re-bases onto the trunk.
 	if base, err := git.MergeBase(forkBranches[0].Branch, trunk.Branch); err == nil {
@@ -581,8 +579,6 @@ func maybeForkFromMergedBase(cfg *config.Config, client github.ClientOps, sf *st
 	}
 
 	sf.AddStack(stack.Stack{
-		Prefix:   prefix,
-		Numbered: numbered,
 		Trunk:    trunk,
 		Branches: forkBranches,
 	})

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -125,14 +125,12 @@ func ensureStackNumber(client github.ClientOps, s *stack.Stack) (int, error) {
 	return number, nil
 }
 
-// inputWithPrefill prompts the user for text input with the given prefill
-// already editable in the input field. Unlike survey.Input's Default (which
-// shows in parentheses), this places the prefill text directly in the
-// editable line so the user can append to or modify it. The user's input
-// is rendered in cyan for visual distinction from the prompt message.
-func inputWithPrefill(cfg *config.Config, prompt, prefill string) (string, error) {
+// promptInput prompts the user for a single line of text input. The user's
+// input is rendered in the accent (cyan) color for visual distinction from the
+// prompt message.
+func promptInput(cfg *config.Config, prompt string) (string, error) {
 	if cfg.InputFn != nil {
-		return cfg.InputFn(prompt, prefill)
+		return cfg.InputFn(prompt)
 	}
 
 	stdio := terminal.Stdio{In: cfg.In, Out: cfg.Out, Err: cfg.Err}
@@ -156,7 +154,7 @@ func inputWithPrefill(cfg *config.Config, prompt, prefill string) (string, error
 		fmt.Fprint(cfg.Out, cyanStart)
 	}
 
-	line, err := rr.ReadLineWithDefault(0, []rune(prefill))
+	line, err := rr.ReadLine(0)
 
 	// Reset color after input
 	if useColor {

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -208,7 +208,6 @@ func branchStatusIndicator(cfg *config.Config, s *stack.Stack, b stack.BranchRef
 // JSON output types for gh stack view --json.
 type viewJSONOutput struct {
 	Trunk         string           `json:"trunk"`
-	Prefix        string           `json:"prefix,omitempty"`
 	CurrentBranch string           `json:"currentBranch"`
 	Branches      []viewJSONBranch `json:"branches"`
 }
@@ -233,7 +232,6 @@ type viewJSONPR struct {
 func viewJSON(cfg *config.Config, s *stack.Stack, currentBranch string) error {
 	out := viewJSONOutput{
 		Trunk:         s.Trunk.Branch,
-		Prefix:        s.Prefix,
 		CurrentBranch: currentBranch,
 		Branches:      make([]viewJSONBranch, 0, len(s.Branches)),
 	}

--- a/cmd/view_test.go
+++ b/cmd/view_test.go
@@ -58,8 +58,7 @@ func TestViewJSON(t *testing.T) {
 		{
 			name: "basic stack with PRs",
 			stack: &stack.Stack{
-				Prefix: "feat",
-				Trunk:  stack.BranchRef{Branch: "main", Head: "aaa"},
+				Trunk: stack.BranchRef{Branch: "main", Head: "aaa"},
 				Branches: []stack.BranchRef{
 					{
 						Branch:      "feat/01",
@@ -151,8 +150,7 @@ func TestViewJSON_BranchFields(t *testing.T) {
 	})
 
 	s := &stack.Stack{
-		Prefix: "feat",
-		Trunk:  stack.BranchRef{Branch: "main", Head: "aaa111"},
+		Trunk: stack.BranchRef{Branch: "main", Head: "aaa111"},
 		Branches: []stack.BranchRef{
 			{
 				Branch:      "feat/01",
@@ -181,8 +179,6 @@ func TestViewJSON_BranchFields(t *testing.T) {
 
 	var got viewJSONOutput
 	require.NoError(t, json.Unmarshal(raw, &got))
-
-	assert.Equal(t, "feat", got.Prefix)
 
 	// First branch: merged
 	b0 := got.Branches[0]
@@ -497,8 +493,7 @@ func TestRunViewJSON_MultipleStacks(t *testing.T) {
 func TestRunViewJSON_SingleStack(t *testing.T) {
 	tmpDir := t.TempDir()
 	writeStackFile(t, tmpDir, stack.Stack{
-		Prefix: "feat",
-		Trunk:  stack.BranchRef{Branch: "main", Head: "aaa"},
+		Trunk: stack.BranchRef{Branch: "main", Head: "aaa"},
 		Branches: []stack.BranchRef{
 			{
 				Branch:      "feat/01",
@@ -531,7 +526,6 @@ func TestRunViewJSON_SingleStack(t *testing.T) {
 	var got viewJSONOutput
 	require.NoError(t, json.Unmarshal(raw, &got), "output should be valid JSON: %s", string(raw))
 	assert.Equal(t, "main", got.Trunk)
-	assert.Equal(t, "feat", got.Prefix)
 	assert.Len(t, got.Branches, 1)
 	assert.Equal(t, "feat/01", got.Branches[0].Name)
 	assert.True(t, got.Branches[0].IsCurrent)

--- a/docs/src/content/docs/guides/workflows.md
+++ b/docs/src/content/docs/guides/workflows.md
@@ -39,40 +39,40 @@ gh stack sync
 
 ## Abbreviated Workflow
 
-For speed, use a branch prefix with `--numbered` and the `-Am` flags to fold staging, committing, and branch creation into a single command. Branch names are auto-generated as `prefix/01`, `prefix/02`, etc.
+For speed, use the `-Am` flags to fold staging, committing, and branch creation into a single command. When you don't pass a branch name, one is auto-generated from the commit message in date+slug format (e.g., `03-24-auth_middleware`).
 
 ```sh
 # Alias `gh stack` as `gs` for easier use
 gh stack alias
 
-# 1. Start a stack with numbered branches
-gs init -p feat --numbered
-#    → creates feat/01 and checks it out
+# 1. Start a stack
+gs init auth
+#    → creates auth and checks it out
 
 # 2. Write code for the first layer
 # ... write code ...
 
 # 3. Stage and commit on the current branch
 gs add -Am "Auth middleware"
-#    → feat/01 has no commits yet, so the commit lands here
+#    → auth has no commits yet, so the commit lands here
 
 # 4. Write code for the next layer
 # ... write code ...
 
 # 5. Create the next branch and commit
 gs add -Am "API routes"
-#    → feat/01 already has commits, so feat/02 is created
+#    → auth already has commits, so a new branch is created
 
 # 6. Keep going
 # ... write code ...
 gs add -Am "Frontend components"
-#    → creates feat/03
+#    → creates another branch
 
 # 7. Push everything and create PRs
 gs submit
 ```
 
-Each `gs add -Am "..."` stages all files, commits, and (if the current branch already has commits) creates a new branch — no separate `git add` or `git commit` needed.
+Each `gs add -Am "..."` stages all files, commits, and (if the current branch already has commits) creates a new branch — no separate `git add` or `git commit` needed. Pass an explicit branch name any time you want to control it: `gs add -Am "API routes" api-routes`.
 
 ## Making Mid-Stack Changes
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -27,19 +27,15 @@ Initialize a new stack in the current repository.
 gh stack init [flags] [branches...]
 ```
 
-Initializes a new stack locally. In interactive mode (no arguments), prompts for a branch name and offers to use the current branch as the first layer. If a branch name contains slashes (e.g., `feat/api`), prompts if you would like to use a prefix (e.g., `feat/`) for all branches in the stack.
+Initializes a new stack locally. In interactive mode (no arguments), prompts for a branch name and offers to use the current branch as the first layer.
 
 When explicit branch names are given, existing branches are adopted automatically and any missing branches are created. The trunk defaults to the repository's default branch unless overridden with `--base`.
-
-Use `--numbered` with `--prefix` to enable auto-incrementing branch names (`prefix/01`, `prefix/02`, …).
 
 Enables `git rerere` automatically so that conflict resolutions are remembered across rebases.
 
 | Flag | Description |
 |------|-------------|
 | `-b, --base <branch>` | Trunk branch for the stack (defaults to the repository's default branch) |
-| `-p, --prefix <string>` | Set a branch name prefix for the stack |
-| `-n, --numbered` | Use auto-incrementing numbered branch names (requires `--prefix`) |
 
 **Examples:**
 
@@ -55,14 +51,6 @@ gh stack init --base develop feature-auth
 
 # Adopt or create multiple branches at once
 gh stack init feature-auth feature-api feature-ui
-
-# Set a prefix — prompts for a branch name suffix
-gh stack init -p feat
-#    → type "auth" → creates feat/auth
-
-# Use numbered auto-incrementing branch names
-gh stack init -p feat --numbered
-#    → creates feat/01 automatically
 ```
 
 ### `gh stack add`
@@ -75,7 +63,7 @@ gh stack add [flags] [branch]
 
 Creates a new branch at the current HEAD, adds it to the top of the stack, and checks it out. Must be run while on the topmost branch of a stack. If no branch name is given, prompts for one.
 
-You can optionally stage changes and create a commit as part of the `add` flow. When `-m` is provided without an explicit branch name, the branch name is auto-generated. If the stack was created with `--numbered`, auto-generated names use numbered format (`prefix/01`, `prefix/02`); otherwise, date+slug format is used.
+You can optionally stage changes and create a commit as part of the `add` flow. When `-m` is provided without an explicit branch name, the branch name is auto-generated in date+slug format (e.g., `03-24-add_login`).
 
 | Flag | Description |
 |------|-------------|

--- a/internal/branch/name.go
+++ b/internal/branch/name.go
@@ -35,8 +35,16 @@ func Slugify(message string) string {
 	// underscore. Hyphens present in the message are allowed and preserved.
 	s = nonAllowedRe.ReplaceAllString(s, "_")
 
-	// Collapse any run of adjacent separators into a single underscore.
-	s = multiSepRe.ReplaceAllString(s, "_")
+	// Collapse any run of adjacent separators into a single character. A run
+	// that contains a hyphen the user actually typed collapses to a hyphen so
+	// literal hyphens survive (e.g. "fix--retry" → "fix-retry"); runs of purely
+	// generated underscores collapse to a single underscore.
+	s = multiSepRe.ReplaceAllStringFunc(s, func(run string) string {
+		if strings.ContainsRune(run, '-') {
+			return "-"
+		}
+		return "_"
+	})
 
 	// Trim leading/trailing separators
 	s = strings.Trim(s, "-_")

--- a/internal/branch/name.go
+++ b/internal/branch/name.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	nonAlphanumRe = regexp.MustCompile(`[^a-z0-9-]+`)
-	multiHyphenRe = regexp.MustCompile(`-{2,}`)
+	nonAllowedRe = regexp.MustCompile(`[^a-z0-9-]+`)
+	multiSepRe   = regexp.MustCompile(`[-_]{2,}`)
 )
 
 // Slugify converts a message into a URL/branch-safe slug.
-// Lowercases, replaces special chars with hyphens, strips consecutive hyphens,
-// and truncates to ~50 chars at a word boundary.
+// Lowercases, replaces spaces and other disallowed characters with underscores
+// (any hyphens already present in the message are preserved), collapses runs of
+// adjacent separators, and truncates to ~30 chars at a word boundary.
 func Slugify(message string) string {
 	// Normalize unicode and lowercase
 	s := strings.ToLower(norm.NFKD.String(message))
@@ -30,31 +31,33 @@ func Slugify(message string) string {
 	}
 	s = b.String()
 
-	// Replace non-alphanumeric chars with hyphens
-	s = nonAlphanumRe.ReplaceAllString(s, "-")
+	// Replace runs of disallowed chars (spaces, punctuation, …) with a single
+	// underscore. Hyphens present in the message are allowed and preserved.
+	s = nonAllowedRe.ReplaceAllString(s, "_")
 
-	// Collapse consecutive hyphens
-	s = multiHyphenRe.ReplaceAllString(s, "-")
+	// Collapse any run of adjacent separators into a single underscore.
+	s = multiSepRe.ReplaceAllString(s, "_")
 
-	// Trim leading/trailing hyphens
-	s = strings.Trim(s, "-")
+	// Trim leading/trailing separators
+	s = strings.Trim(s, "-_")
 
-	// Truncate to ~50 chars at word boundary
-	if len(s) > 50 {
-		s = s[:50]
-		if idx := strings.LastIndex(s, "-"); idx > 0 {
+	// Truncate to ~30 chars at a word boundary (underscore)
+	if len(s) > 30 {
+		s = s[:30]
+		if idx := strings.LastIndex(s, "_"); idx > 0 {
 			s = s[:idx]
 		}
+		s = strings.Trim(s, "-_")
 	}
 
 	return s
 }
 
-// DateSlug returns a branch name in the format YYYY-MM-DD-slugified-message.
+// DateSlug returns a branch name in the format MM-DD-slugified-message.
 // It is used to auto-generate a branch name from a commit message when no
 // explicit branch name is provided.
 func DateSlug(message string) string {
-	date := time.Now().Format("2006-01-02")
+	date := time.Now().Format("01-02")
 	slug := Slugify(message)
 	if slug == "" {
 		return date

--- a/internal/branch/name.go
+++ b/internal/branch/name.go
@@ -1,9 +1,7 @@
 package branch
 
 import (
-	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -12,9 +10,8 @@ import (
 )
 
 var (
-	nonAlphanumRe    = regexp.MustCompile(`[^a-z0-9-]+`)
-	multiHyphenRe    = regexp.MustCompile(`-{2,}`)
-	numberedBranchRe = regexp.MustCompile(`/(\d+)$`)
+	nonAlphanumRe = regexp.MustCompile(`[^a-z0-9-]+`)
+	multiHyphenRe = regexp.MustCompile(`-{2,}`)
 )
 
 // Slugify converts a message into a URL/branch-safe slug.
@@ -54,6 +51,8 @@ func Slugify(message string) string {
 }
 
 // DateSlug returns a branch name in the format YYYY-MM-DD-slugified-message.
+// It is used to auto-generate a branch name from a commit message when no
+// explicit branch name is provided.
 func DateSlug(message string) string {
 	date := time.Now().Format("2006-01-02")
 	slug := Slugify(message)
@@ -61,72 +60,4 @@ func DateSlug(message string) string {
 		return date
 	}
 	return date + "-" + slug
-}
-
-// FollowsNumbering returns true if branchName matches the pattern {prefix}/\d+.
-func FollowsNumbering(prefix, branchName string) bool {
-	if !strings.HasPrefix(branchName, prefix+"/") {
-		return false
-	}
-	suffix := branchName[len(prefix)+1:]
-	_, err := strconv.Atoi(suffix)
-	return err == nil
-}
-
-// NextNumberedName scans existingBranches for the highest number matching
-// {prefix}/NN and returns {prefix}/{next} with zero-padded two digits.
-func NextNumberedName(prefix string, existingBranches []string) string {
-	maxNum := 0
-	for _, b := range existingBranches {
-		if m := numberedBranchRe.FindStringSubmatch(b); m != nil {
-			if strings.HasPrefix(b, prefix+"/") {
-				n, _ := strconv.Atoi(m[1])
-				if n > maxNum {
-					maxNum = n
-				}
-			}
-		}
-	}
-	return fmt.Sprintf("%s/%02d", prefix, maxNum+1)
-}
-
-// ResolveBranchName implements the full decision tree for branch name generation.
-//
-// Parameters:
-//   - prefix: configured stack prefix (may be empty)
-//   - message: commit message (from -m flag; may be empty if not using auto-naming)
-//   - explicitName: branch name provided as argument (may be empty)
-//   - existingBranches: current branch names in the stack
-//   - numbered: true if the stack uses auto-incrementing numbered branches
-//
-// Returns the resolved branch name and an informational message (may be empty).
-func ResolveBranchName(prefix, message, explicitName string, existingBranches []string, numbered bool) (name string, info string) {
-	if explicitName != "" {
-		// Explicit name provided
-		if prefix != "" {
-			name = prefix + "/" + explicitName
-			info = fmt.Sprintf("Branch name prefixed: %s", name)
-		} else {
-			name = explicitName
-		}
-		return
-	}
-
-	// Auto-generate from message
-	if message == "" {
-		return "", ""
-	}
-
-	if prefix != "" {
-		if numbered {
-			name = NextNumberedName(prefix, existingBranches)
-		} else {
-			name = prefix + "/" + DateSlug(message)
-		}
-	} else {
-		// No prefix — always use date+slug
-		name = DateSlug(message)
-	}
-
-	return
 }

--- a/internal/branch/name_test.go
+++ b/internal/branch/name_test.go
@@ -20,6 +20,9 @@ func TestSlugify(t *testing.T) {
 		{"diacritics stripped", "café résumé", "cafe_resume"},
 		{"special chars become underscores", "feat: add login!", "feat_add_login"},
 		{"real hyphens preserved", "Add user-authentication", "add_user-authentication"},
+		{"adjacent hyphens preserved as a hyphen", "fix--retry", "fix-retry"},
+		{"hyphen next to a space preserved as a hyphen", "fix- retry", "fix-retry"},
+		{"spaced dash preserved as a hyphen", "fix - retry", "fix-retry"},
 		{"empty string", "", ""},
 	}
 

--- a/internal/branch/name_test.go
+++ b/internal/branch/name_test.go
@@ -16,9 +16,10 @@ func TestSlugify(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"spaces to hyphens", "Hello World", "hello-world"},
-		{"diacritics stripped", "café résumé", "cafe-resume"},
-		{"special chars removed", "feat: add login!", "feat-add-login"},
+		{"spaces to underscores", "Hello World", "hello_world"},
+		{"diacritics stripped", "café résumé", "cafe_resume"},
+		{"special chars become underscores", "feat: add login!", "feat_add_login"},
+		{"real hyphens preserved", "Add user-authentication", "add_user-authentication"},
 		{"empty string", "", ""},
 	}
 
@@ -31,8 +32,9 @@ func TestSlugify(t *testing.T) {
 	t.Run("long string truncated at word boundary", func(t *testing.T) {
 		long := "this is a very long commit message that should definitely be truncated at a word boundary"
 		result := Slugify(long)
-		assert.LessOrEqual(t, len(result), 50)
-		assert.False(t, strings.HasSuffix(result, "-"), "should not end with hyphen")
+		assert.LessOrEqual(t, len(result), 30)
+		assert.False(t, strings.HasSuffix(result, "_"), "should not end with a separator")
+		assert.False(t, strings.HasSuffix(result, "-"), "should not end with a separator")
 		assert.NotEmpty(t, result)
 	})
 }
@@ -40,11 +42,11 @@ func TestSlugify(t *testing.T) {
 // --- DateSlug: date-prefixed auto-naming ---
 
 func TestDateSlug(t *testing.T) {
-	today := time.Now().Format("2006-01-02")
+	today := time.Now().Format("01-02")
 
 	t.Run("prefixes the date and slugifies the message", func(t *testing.T) {
 		name := DateSlug("Add login")
-		assert.Equal(t, today+"-add-login", name)
+		assert.Equal(t, today+"-add_login", name)
 	})
 
 	t.Run("empty message returns just the date", func(t *testing.T) {

--- a/internal/branch/name_test.go
+++ b/internal/branch/name_test.go
@@ -37,96 +37,17 @@ func TestSlugify(t *testing.T) {
 	})
 }
 
-// --- FollowsNumbering: pattern detection ---
+// --- DateSlug: date-prefixed auto-naming ---
 
-func TestFollowsNumbering(t *testing.T) {
-	tests := []struct {
-		name     string
-		prefix   string
-		branch   string
-		expected bool
-	}{
-		{"matching pattern", "stack", "stack/1", true},
-		{"multi-digit", "stack", "stack/42", true},
-		{"non-numeric suffix", "stack", "stack/abc", false},
-		{"wrong prefix", "other", "stack/1", false},
-		{"empty suffix", "stack", "stack/", false},
-	}
+func TestDateSlug(t *testing.T) {
+	today := time.Now().Format("2006-01-02")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, FollowsNumbering(tt.prefix, tt.branch))
-		})
-	}
-}
-
-// --- NextNumberedName: auto-increment ---
-
-func TestNextNumberedName(t *testing.T) {
-	t.Run("empty list starts at 01", func(t *testing.T) {
-		assert.Equal(t, "prefix/01", NextNumberedName("prefix", nil))
+	t.Run("prefixes the date and slugifies the message", func(t *testing.T) {
+		name := DateSlug("Add login")
+		assert.Equal(t, today+"-add-login", name)
 	})
 
-	t.Run("increments from highest", func(t *testing.T) {
-		branches := []string{"prefix/01", "prefix/02"}
-		assert.Equal(t, "prefix/03", NextNumberedName("prefix", branches))
-	})
-
-	t.Run("handles gaps by using max", func(t *testing.T) {
-		branches := []string{"prefix/01", "prefix/05"}
-		assert.Equal(t, "prefix/06", NextNumberedName("prefix", branches))
-	})
-
-	t.Run("ignores branches with different prefix", func(t *testing.T) {
-		branches := []string{"other/10", "prefix/02"}
-		assert.Equal(t, "prefix/03", NextNumberedName("prefix", branches))
-	})
-}
-
-// --- ResolveBranchName: the full decision tree ---
-
-func TestResolveBranchName(t *testing.T) {
-	t.Run("explicit name with prefix uses slash separator", func(t *testing.T) {
-		name, info := ResolveBranchName("mystack", "", "feature", nil, false)
-		assert.Equal(t, "mystack/feature", name)
-		assert.Contains(t, info, "prefixed")
-	})
-
-	t.Run("explicit name without prefix uses name as-is", func(t *testing.T) {
-		name, info := ResolveBranchName("", "", "feature", nil, false)
-		assert.Equal(t, "feature", name)
-		assert.Empty(t, info)
-	})
-
-	t.Run("message with prefix and numbered uses numbered format", func(t *testing.T) {
-		name, _ := ResolveBranchName("stack", "add login", "", nil, true)
-		assert.Equal(t, "stack/01", name)
-	})
-
-	t.Run("message with prefix and numbered continues sequence", func(t *testing.T) {
-		existing := []string{"stack/01", "stack/02"}
-		name, _ := ResolveBranchName("stack", "add login", "", existing, true)
-		assert.Equal(t, "stack/03", name)
-	})
-
-	t.Run("message with prefix not numbered uses date-slug", func(t *testing.T) {
-		existing := []string{"stack/some-feature"}
-		name, _ := ResolveBranchName("stack", "add login", "", existing, false)
-		today := time.Now().Format("2006-01-02")
-		assert.True(t, strings.HasPrefix(name, "stack/"+today), "expected date prefix, got: %s", name)
-		assert.Contains(t, name, "add-login")
-	})
-
-	t.Run("message without prefix uses date-slug", func(t *testing.T) {
-		name, _ := ResolveBranchName("", "add login", "", nil, false)
-		today := time.Now().Format("2006-01-02")
-		assert.True(t, strings.HasPrefix(name, today))
-		assert.Contains(t, name, "add-login")
-	})
-
-	t.Run("no message no name returns empty", func(t *testing.T) {
-		name, info := ResolveBranchName("stack", "", "", nil, false)
-		assert.Empty(t, name)
-		assert.Empty(t, info)
+	t.Run("empty message returns just the date", func(t *testing.T) {
+		assert.Equal(t, today, DateSlug(""))
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,7 @@ type Config struct {
 
 	// InputFn, when non-nil, is called instead of prompting via the
 	// terminal. Used in tests to simulate text input prompts.
-	InputFn func(prompt, defaultValue string) (string, error)
+	InputFn func(prompt string) (string, error)
 
 	// RepoOverride, when non-nil, is returned by Repo() instead of
 	// calling repository.Current(). Used in tests to avoid depending on

--- a/internal/stack/schema.json
+++ b/internal/stack/schema.json
@@ -34,14 +34,6 @@
           "type": "integer",
           "description": "Repo-scoped number identifying this stack, displayed in the GitHub UI. Used as the primary way to reference a stack."
         },
-        "prefix": {
-          "type": "string",
-          "description": "Branch name prefix for the stack (e.g. 'myfeature')."
-        },
-        "numbered": {
-          "type": "boolean",
-          "description": "Whether to use auto-incrementing numbered branch names."
-        },
         "trunk": {
           "$ref": "#/$defs/branchRef",
           "description": "The trunk (base) branch of the stack."

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -44,8 +44,6 @@ type BranchRef struct {
 type Stack struct {
 	ID       string      `json:"id,omitempty"`
 	Number   int         `json:"number,omitempty"`
-	Prefix   string      `json:"prefix,omitempty"`
-	Numbered bool        `json:"numbered,omitempty"`
 	Trunk    BranchRef   `json:"trunk"`
 	Branches []BranchRef `json:"branches"`
 }

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -236,7 +236,6 @@ func TestLoad_Save_RoundTrip(t *testing.T) {
 				{
 					ID:     "s1",
 					Number: 7,
-					Prefix: "feat",
 					Trunk:  BranchRef{Branch: "main", Head: "abc123"},
 					Branches: []BranchRef{
 						{Branch: "b1", Head: "def456", Base: "abc123"},
@@ -258,7 +257,6 @@ func TestLoad_Save_RoundTrip(t *testing.T) {
 		s := loaded.Stacks[0]
 		assert.Equal(t, "s1", s.ID)
 		assert.Equal(t, 7, s.Number)
-		assert.Equal(t, "feat", s.Prefix)
 		assert.Equal(t, "main", s.Trunk.Branch)
 		assert.Equal(t, "abc123", s.Trunk.Head)
 		require.Len(t, s.Branches, 2)

--- a/skills/gh-stack/SKILL.md
+++ b/skills/gh-stack/SKILL.md
@@ -7,7 +7,7 @@ description: >
   branch chains, or incremental code review workflows.
 metadata:
   author: github
-  version: "0.0.7"
+  version: "0.0.8"
 ---
 
 # gh-stack
@@ -16,9 +16,9 @@ metadata:
 
 ```
 main (trunk)
- └── feat/auth-layer     → PR #1 (base: main)               - bottom (closest to trunk)
-  └── feat/api-endpoints → PR #2 (base: feat/auth-layer)
-   └── feat/frontend     → PR #3 (base: feat/api-endpoints) - top (furthest from trunk)
+ └── auth-layer     → PR #1 (base: main)            - bottom (closest to trunk)
+  └── api-endpoints → PR #2 (base: auth-layer)
+   └── frontend     → PR #3 (base: api-endpoints)   - top (furthest from trunk)
 ```
 
 The **bottom** of the stack is the branch closest to the trunk, and the **top** is the branch furthest from the trunk. Each branch inherits from the one below it. Navigation commands (`up`, `down`, `top`, `bottom`) follow this model: `up` moves away from trunk, `down` moves toward it.
@@ -52,16 +52,15 @@ git config remote.pushDefault origin     # if multiple remotes exist (skips remo
 
 **All `gh stack` commands must be run non-interactively.** Every command invocation must include the flags and positional arguments needed to avoid prompts, TUIs, and interactive menus. If a command would prompt for input, it will hang indefinitely.
 
-1. **Always supply branch names as positional arguments** to `init`, `add`, and `checkout`. Running these commands without arguments triggers interactive prompts.
-2. **When a prefix is set, pass only the suffix to `add`.** `gh stack add auth` with prefix `feat` → `feat/auth`. Passing `feat/auth` creates `feat/feat/auth`.
-3. **Always use `--auto` with `gh stack submit`** to auto-generate PR titles. Without `--auto`, `submit` prompts for a title for each new PR.
-4. **Always use `--json` with `gh stack view`.** Without `--json`, the command launches an interactive TUI that cannot be operated by agents. There is no other appropriate flag — always pass `--json`.
-5. **Use `--remote <name>` when multiple remotes are configured**, or pre-configure `git config remote.pushDefault origin`. Without this, `push`, `submit`, `sync`, `link`, and `checkout` trigger an interactive remote picker.
-6. **Avoid branches shared across multiple stacks.** If a branch belongs to multiple stacks, commands exit with code 6. Check out a non-shared branch first.
-7. **Plan your stack layers by dependency order before writing code.** Foundational changes (models, APIs, shared utilities) go in lower branches; dependent changes (UI, consumers) go in higher branches. Think through the dependency chain before running `gh stack init`.
-8. **Use standard `git add` and `git commit` for staging and committing.** This gives you full control over which changes go into each branch. The `-Am` shortcut is available but should not be the default approach—stacked PRs are most effective when each branch contains a deliberate, logical set of changes.
-9. **Navigate down the stack when you need to change a lower layer.** If you're working on a frontend branch and realize you need API changes, don't hack around it at the current layer. Navigate to the appropriate branch (`gh stack down`, `gh stack checkout`, or `gh stack bottom`), make and commit the changes there, run `gh stack rebase --upstack`, then navigate back up to continue.
-10. **Use `gh stack link` for external tool workflows.** When branches are managed by an external tool (jj, Sapling, etc.), use `gh stack link branch-a branch-b`. `link` does not rely on local tracking state and is intended for API-driven PR and stack management. Provide at least two branches/PRs to create or update a stack, or a stack number followed by the new branches/PRs to append them to the top of an existing stack (e.g. `gh stack link 7 branch-c`).
+1. **Always supply branch names as positional arguments** to `init`, `add`, and `checkout`. Running these commands without arguments triggers interactive prompts. Branch names are used exactly as given — a name is never prefixed or transformed, so `gh stack add refactor/foo` creates a branch named `refactor/foo`.
+2. **Always use `--auto` with `gh stack submit`** to auto-generate PR titles. Without `--auto`, `submit` prompts for a title for each new PR.
+3. **Always use `--json` with `gh stack view`.** Without `--json`, the command launches an interactive TUI that cannot be operated by agents. There is no other appropriate flag — always pass `--json`.
+4. **Use `--remote <name>` when multiple remotes are configured**, or pre-configure `git config remote.pushDefault origin`. Without this, `push`, `submit`, `sync`, `link`, and `checkout` trigger an interactive remote picker.
+5. **Avoid branches shared across multiple stacks.** If a branch belongs to multiple stacks, commands exit with code 6. Check out a non-shared branch first.
+6. **Plan your stack layers by dependency order before writing code.** Foundational changes (models, APIs, shared utilities) go in lower branches; dependent changes (UI, consumers) go in higher branches. Think through the dependency chain before running `gh stack init`.
+7. **Use standard `git add` and `git commit` for staging and committing.** This gives you full control over which changes go into each branch. The `-Am` shortcut is available but should not be the default approach—stacked PRs are most effective when each branch contains a deliberate, logical set of changes.
+8. **Navigate down the stack when you need to change a lower layer.** If you're working on a frontend branch and realize you need API changes, don't hack around it at the current layer. Navigate to the appropriate branch (`gh stack down`, `gh stack checkout`, or `gh stack bottom`), make and commit the changes there, run `gh stack rebase --upstack`, then navigate back up to continue.
+9. **Use `gh stack link` for external tool workflows.** When branches are managed by an external tool (jj, Sapling, etc.), use `gh stack link branch-a branch-b`. `link` does not rely on local tracking state and is intended for API-driven PR and stack management. Provide at least two branches/PRs to create or update a stack, or a stack number followed by the new branches/PRs to append them to the top of an existing stack (e.g. `gh stack link 7 branch-c`).
 
 **Never do any of the following — each triggers an interactive prompt or TUI that will hang:**
 - ❌ `gh stack view` or `gh stack view --short` — always use `gh stack view --json`
@@ -83,24 +82,24 @@ Stacked branches form a dependency chain: each branch builds on the one below it
 
 ```
 main (trunk)
- └── feat/data-models    ← shared types, database schema
-  └── feat/api-endpoints ← API routes that use the models
-   └── feat/frontend-ui  ← UI components that call the APIs
-    └── feat/integration ← tests that exercise the full stack
+ └── data-models    ← shared types, database schema
+  └── api-endpoints ← API routes that use the models
+   └── frontend-ui  ← UI components that call the APIs
+    └── integration ← tests that exercise the full stack
 ```
 
 This is illustrative — choose branch names and layer boundaries that reflect the specific work you're doing. The key principle is: if code in one layer depends on code in another, the dependency must be in the same branch or a lower one.
 
 ### Branch naming
 
-Prefer initializing stacks with a prefix (`-p`). Prefixes group branches under a namespace (e.g., `feat/auth`, `feat/api`) and keep branch names clean and consistent. When a prefix is set, pass only the suffix to subsequent `add` calls — the prefix is applied automatically. Without a prefix, you'll need to pass the full branch name each time.
+Choose a clear, descriptive branch name for each layer that reflects the concern it contains (e.g., `auth`, `api-routes`, `frontend`). Branch names are used exactly as you provide them to `init` and `add` — nothing is prepended or transformed. Slashes are allowed and are treated as part of the name (e.g., `gh stack add refactor/foo` creates a branch named `refactor/foo`).
 
 ### Staging changes deliberately
 
 The main reason to use `git add` and `git commit` directly is to control **which changes go into which branch**. When you have multiple files in your working tree, you can stage a subset for the current branch, commit them, then create a new branch and stage the rest there:
 
 ```bash
-# You're on feat/data-models with several new files in your working tree.
+# You're on data-models with several new files in your working tree.
 # Stage only the model files for this branch:
 git add internal/models/user.go internal/models/session.go
 git commit -m "Add user and session models"
@@ -109,7 +108,7 @@ git add db/migrations/001_create_users.sql
 git commit -m "Add user table migration"
 
 # Now create a new branch for the API layer and stage the API files there:
-gh stack add api-routes # created & switched to feat/api-routes branch
+gh stack add api-routes # created & switched to the api-routes branch
 git add internal/api/routes.go internal/api/handlers.go
 git commit -m "Add user API routes"
 ```
@@ -139,12 +138,11 @@ Small, incidental fixes (e.g., fixing a typo you noticed) can go in the current 
 
 | Task | Command |
 |------|---------|
-| Create a stack (recommended) | `gh stack init -p feat auth` |
-| Create a stack without prefix | `gh stack init auth` |
+| Create a stack | `gh stack init auth` |
 | Create a stack of multiple branches | `gh stack init auth api frontend` |
 | Adopt existing branches | `gh stack init existing-branch-a existing-branch-b` |
 | Set custom trunk | `gh stack init --base develop branch-a` |
-| Add a branch to stack (suffix only if prefix set) | `gh stack add api-routes` |
+| Add a branch to stack | `gh stack add api-routes` |
 | Add branch + stage all + commit | `gh stack add -Am "message" api-routes` |
 | Push branches to remote | `gh stack push` |
 | Push to specific remote | `gh stack push --remote origin` |
@@ -175,8 +173,8 @@ Small, incidental fixes (e.g., fixing a typo you noticed) can go in the current 
 
 ```bash
 # 1. Initialize a stack with the first branch
-gh stack init -p feat auth
-# → creates feat/auth and checks it out
+gh stack init auth
+# → creates auth and checks it out
 
 # 2. Write code for the first layer (auth)
 cat > auth.go << 'EOF'
@@ -207,7 +205,7 @@ git commit -m "Add auth middleware tests"
 
 # 4. When you're ready for a new concern, add the next branch
 gh stack add api-routes
-# → creates feat/api-routes (prefix applied automatically — just pass the suffix)
+# → creates api-routes
 
 # 5. Write code for the API layer
 cat > api.go << 'EOF'
@@ -222,7 +220,7 @@ git commit -m "Add API routes"
 
 # 6. Add a third layer for frontend
 gh stack add frontend
-# → creates feat/frontend (just the suffix — prefix is automatic)
+# → creates frontend
 
 cat > frontend.go << 'EOF'
 package frontend
@@ -234,7 +232,7 @@ EOF
 git add frontend.go
 git commit -m "Add frontend dashboard"
 
-# ── Stack complete: feat/auth → feat/api-routes → feat/frontend ──
+# ── Stack complete: auth → api-routes → frontend ──
 
 # 7. Push everything and create PRs (drafts by default)
 gh stack submit --auto
@@ -250,11 +248,11 @@ gh stack view --json
 This is a critical workflow for agents. When you're working on a higher layer and realize you need to change something in a lower layer (e.g., you're building frontend components but need to add an API endpoint), **navigate down to the correct branch, make the change there, and rebase**.
 
 ```bash
-# You're on feat/frontend but need to add an API endpoint
+# You're on frontend but need to add an API endpoint
 
 # 1. Navigate to the API branch
 gh stack down
-# or: gh stack checkout feat/api-routes
+# or: gh stack checkout api-routes
 
 # 2. Make the change where it belongs
 cat > users_api.go << 'EOF'
@@ -272,7 +270,7 @@ gh stack rebase --upstack
 
 # 4. Navigate back to where you were working
 gh stack top
-# or: gh stack checkout feat/frontend
+# or: gh stack checkout frontend
 
 # 5. Continue working — the API changes are now available
 ```
@@ -286,7 +284,7 @@ When you need to revisit a branch after the initial creation (e.g., responding t
 ```bash
 # 1. Navigate to the branch that needs changes
 gh stack bottom
-# or: gh stack checkout feat/auth
+# or: gh stack checkout auth
 # or: gh stack checkout 42  (by PR number)
 
 # 2. Make changes and commit
@@ -323,18 +321,18 @@ gh stack sync --prune
 When a PR is squash-merged on GitHub, the original branch's commits no longer exist in the trunk history. `gh stack` detects this automatically and uses `git rebase --onto` to correctly replay remaining commits.
 
 ```bash
-# After PR #1 (feat/auth) is squash-merged on GitHub:
+# After PR #1 (auth) is squash-merged on GitHub:
 gh stack sync
 # → fetches latest, detects the merge, fast-forwards trunk
-# → rebases feat/api-routes onto updated trunk (skips merged branch)
-# → rebases feat/frontend onto feat/api-routes
+# → rebases api-routes onto updated trunk (skips merged branch)
+# → rebases frontend onto api-routes
 # → pushes updated branches
 # → reports: "Merged: #1"
 
 # Verify the result
 gh stack view --json
-# → feat/auth shows "isMerged": true, "state": "MERGED"
-# → feat/api-routes and feat/frontend show updated heads
+# → auth shows "isMerged": true, "state": "MERGED"
+# → api-routes and frontend show updated heads
 ```
 
 If `sync` hits a conflict during this process, it restores all branches to their pre-rebase state and exits with code 3. See [Handle rebase conflicts](#handle-rebase-conflicts-agent-workflow) for the resolution workflow.
@@ -415,15 +413,11 @@ gh stack init [flags] <branches...>
 ```
 
 ```bash
-# Set a branch prefix (recommended — subsequent `add` calls only need the suffix)
-gh stack init -p feat auth
-# → creates feat/auth
+# Create a stack with a new branch
+gh stack init auth
+# → creates auth and checks it out
 
-# Multi-part prefix (slashes are fine — suffix-only rule still applies)
-gh stack init -p monalisa/billing auth
-# → creates monalisa/billing/auth
-
-# Create a stack with new branches (no prefix — use full branch names)
+# Create a stack with new branches
 gh stack init branch-a branch-b branch-c
 
 # Use a different trunk branch
@@ -436,11 +430,10 @@ gh stack init branch-a branch-b branch-c
 | Flag | Description |
 |------|-------------|
 | `-b, --base <branch>` | Trunk branch (defaults to the repo's default branch) |
-| `-p, --prefix <string>` | Branch name prefix. Subsequent `add` calls only need the suffix (e.g., with `-p feat`, `gh stack add auth` creates `feat/auth`) |
 
 **Behavior:**
 
-- Using `-p` is recommended — it simplifies branch naming for subsequent `add` calls
+- Branch names are created exactly as given (slashes are allowed and kept as-is)
 - Creates any branches that don't already exist (branching from the trunk branch)
 - Existing branches are adopted automatically; missing branches are created from the trunk
 - Checks out the last branch in the list
@@ -459,7 +452,7 @@ gh stack add [flags] <branch>
 **Recommended workflow — create the branch, then use standard git:**
 
 ```bash
-# Create a new branch and switch to it (just the suffix — prefix is applied automatically)
+# Create a new branch and switch to it
 gh stack add api-routes
 
 # Write code, stage deliberately, and commit
@@ -491,7 +484,7 @@ gh stack add -um "Fix auth bug" auth-fix
 
 - `-A` and `-u` are mutually exclusive.
 - When the current branch has no commits (e.g., right after `init`), `add -Am` commits directly on the current branch instead of creating a new one.
-- **Prefix handling:** Only pass the suffix when a prefix is set. `gh stack add api` with prefix `todo` → `todo/api`. Passing `todo/api` creates `todo/todo/api`. Without a prefix, pass the full branch name.
+- **Branch names are used verbatim.** `gh stack add refactor/foo` creates a branch named `refactor/foo` — names are never prefixed or transformed. When `-m` is given without a branch name, the name is auto-generated from the commit message in date+slug format (e.g., `03-24-add_api_routes`).
 - If called from a branch that is not the topmost in the stack, exits with code 5: `"can only add branches on top of the stack"`. Use `gh stack top` to switch first.
 - **Uncommitted changes:** When using `gh stack add branch-name` without `-Am`, any uncommitted changes (staged or unstaged) in your working tree carry over to the new branch. This is standard git behavior — the working tree is not touched. Commit or stash changes on the current branch before running `add` if you want a clean starting point on the new branch.
 
@@ -732,11 +725,10 @@ gh stack view --json
 ```json
 {
   "trunk": "main",
-  "prefix": "feat",
-  "currentBranch": "feat/api-routes",
+  "currentBranch": "api-routes",
   "branches": [
     {
-      "name": "feat/auth",
+      "name": "auth",
       "head": "abc1234...",
       "base": "def5678...",
       "isCurrent": false,
@@ -749,7 +741,7 @@ gh stack view --json
       }
     },
     {
-      "name": "feat/api-routes",
+      "name": "api-routes",
       "head": "789abcd...",
       "base": "abc1234...",
       "isCurrent": true,


### PR DESCRIPTION
The stack branch-name **prefix** (and the coupled `--numbered` naming) has caused more confusion than it was worth. The behavior was inconsistent — the interactive prompter applied a prefix while explicit names didn't, and passing an already-qualified name double-applied it (`gh stack add refactor/foo` → `feat/refactor/foo`, #152). This removes the concept entirely: from local stack state, the prompts, the `init`/`add` flags, and everywhere it was referenced.

## Behavior

Branch names are now used exactly as given — nothing is ever prepended or transformed.

- **Explicit name** — used verbatim (slashes included), so `gh stack add refactor/foo` creates `refactor/foo`.
- **`-m` without a name** — auto-generated from the commit message as `MM-DD-slug` (e.g. `07-15-add_login`). The slug uses underscores as its word separator, preserves any real hyphens from the message, and is capped at 30 characters.
- **Neither** — prompts for a name (no pre-filled prefix).

Old stack files that still carry `prefix`/`numbered` keys keep loading fine — the fields are ignored and dropped on the next save.

## Changes

**Remove the prefix concept**

- `internal/stack/stack.go`, `schema.json` — drop the `Prefix` and `Numbered` fields from the `Stack` model and schema.
- `cmd/init.go` — remove the `-p, --prefix` and `-n, --numbered` flags, the numbered-branch path, prefix validation, and the interactive "use as a prefix?" detection.
- `cmd/add.go` — collapse branch-name resolution to the three cases above and delete `applyPrefix`.
- `cmd/submit.go`, `cmd/view.go` — stop carrying the prefix through the fork-a-merged-stack path and drop the `prefix` field from `gh stack view --json`.
- `internal/branch/name.go` — delete `ResolveBranchName`, `NextNumberedName`, and `FollowsNumbering`.

**Clean up branch auto-naming**

- `internal/branch/name.go` — `DateSlug` now uses an `MM-DD` prefix (no year); `Slugify` separates words with underscores (keeping literal hyphens) and truncates to 30 characters.
- `cmd/utils.go`, `internal/config/config.go` — simplify the prompt helper to `promptInput` and drop the now-unused prefill parameter from `InputFn`.

**Update docs**

- `README.md`, `docs/src/content/docs/reference/cli.md`, `docs/src/content/docs/guides/workflows.md`, `skills/gh-stack/SKILL.md`, `AGENTS.md` — remove the prefix/numbered flags, examples, and the `prefix` JSON field, and refresh the auto-naming description.

## Testing

- Removed the prefix/numbered tests and added coverage for verbatim explicit names, `-m` date-slug generation, and the new `MM-DD` + underscore + 30-char slug rules.
- `go test -race -count=1 ./...` and `go vet ./...` are clean, and the changed files pass `gofmt`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>