### PR TITLE
navigate down/up with j/k

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ If the stack of PRs has been created on GitHub, run `gh stack submit` afterwards
 - **Fold down** (`d`): Absorb a branch's commits into the branch below (toward trunk). Folded branch removed from stack.
 - **Fold up** (`u`): Absorb a branch's commits into the branch above (away from trunk). Folded branch removed from stack.
 - **Insert** (`i`/`I`): Insert a new empty branch into the stack. `i` inserts below the cursor; `I` inserts above.
-- **Reorder** (`Shift+↑`/`Shift+↓`): Move a branch up (away from trunk) or down (toward trunk) in the stack.
+- **Reorder** (`Shift+↓`/`Shift+↑`): Move a branch down (toward trunk) or up (away from trunk) in the stack.
 - **Rename** (`r`): Rename a branch locally and in the stack metadata.
 - **Undo** (`z`): Undo the last staged action.
 
@@ -263,14 +263,14 @@ If the stack of PRs has been created on GitHub, run `gh stack submit` afterwards
 
 | Key | Action |
 |-----|--------|
-| `↑`/`↓` | Navigate branch list |
+| `↓`/`↑` or `j`/`k` | Navigate branch list |
 | `f` | View files changed |
 | `c` | View commits |
 | `x` | Drop branch |
 | `r` | Rename branch |
 | `i/I` | Insert branch below/above |
 | `d/u` | Fold branch down/up |
-| `Shift+↑`/`Shift+↓` | Move branch up/down |
+| `Shift+↓`/`Shift+↑` | Move branch down/up |
 | `z` | Undo last action |
 | `Ctrl+S` | Apply all changes |
 | `q`/`Esc` | Cancel and exit |

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
-	"github.com/cli/go-gh/v2/pkg/prompter"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/cli/go-gh/v2/pkg/text"
 	"github.com/github/gh-stack/internal/config"
 	"github.com/github/gh-stack/internal/git"
 	"github.com/spf13/cobra"
@@ -17,11 +19,11 @@ func SwitchCmd(cfg *config.Config) *cobra.Command {
 and switch to the selected one.
 
 Branches are displayed from top (furthest from trunk) to bottom (closest to
-trunk) with their position number. Use the arrow keys to navigate and Enter
-to select.
+trunk) with their position number. Use the down/up arrow keys or j/k to
+navigate and Enter to select.
 
-To move one branch up or down without an interactive picker, use
-'gh stack up' or 'gh stack down' instead.`,
+To move one branch down or up without an interactive picker, use
+'gh stack down' or 'gh stack up' instead.`,
 		Example: `  # Open the branch picker for the current stack
   $ gh stack switch`,
 		Args: cobra.NoArgs,
@@ -61,17 +63,7 @@ func runSwitch(cfg *config.Config) error {
 		}
 	}
 
-	var selectFn func(prompt, def string, opts []string) (int, error)
-	if cfg.SelectFn != nil {
-		selectFn = cfg.SelectFn
-	} else {
-		p := prompter.New(cfg.In, cfg.Out, cfg.Err)
-		selectFn = func(prompt, def string, opts []string) (int, error) {
-			return p.Select(prompt, def, opts)
-		}
-	}
-
-	selected, err := selectFn("Select a branch in the stack to switch to:", defaultOpt, options)
+	selected, err := selectSwitchBranch(cfg, "Select a branch in the stack to switch to:", defaultOpt, options)
 	if err != nil {
 		if isInterruptError(err) {
 			clearSelectPrompt(cfg, len(options))
@@ -102,4 +94,47 @@ func runSwitch(cfg *config.Config) error {
 
 	cfg.Successf("Switched to %s", targetBranch)
 	return nil
+}
+
+func selectSwitchBranch(cfg *config.Config, prompt, defaultValue string, options []string) (int, error) {
+	if cfg.SelectFn != nil {
+		return cfg.SelectFn(prompt, defaultValue, options)
+	}
+
+	var selected int
+	err := survey.AskOne(
+		newSwitchSelect(prompt, defaultValue, options),
+		&selected,
+		survey.WithStdio(cfg.In, cfg.Out, cfg.Err),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("could not prompt: %w", err)
+	}
+	return selected, nil
+}
+
+func newSwitchSelect(prompt, defaultValue string, options []string) *survey.Select {
+	selectPrompt := &survey.Select{
+		Message:  prompt,
+		Options:  options,
+		PageSize: selectPromptPageSize,
+		VimMode:  true,
+		Filter:   switchSelectFilter,
+	}
+	if defaultValue != "" {
+		for _, option := range options {
+			if option == defaultValue {
+				selectPrompt.Default = defaultValue
+				break
+			}
+		}
+	}
+	return selectPrompt
+}
+
+func switchSelectFilter(filter, value string, _ int) bool {
+	filter = strings.ToLower(filter)
+	value = strings.ToLower(value)
+	return strings.Contains(value, filter) ||
+		strings.Contains(text.RemoveDiacritics(value), filter)
 }

--- a/cmd/switch_test.go
+++ b/cmd/switch_test.go
@@ -271,3 +271,21 @@ func TestSwitch_CmdIntegration(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err)
 }
+
+func TestNewSwitchSelect_EnablesVimNavigation(t *testing.T) {
+	options := []string{"3. résumé", "2. b2", "1. b1"}
+	prompt := newSwitchSelect("Select a branch:", "2. b2", options)
+
+	assert.True(t, prompt.VimMode)
+	assert.Equal(t, selectPromptPageSize, prompt.PageSize)
+	assert.Equal(t, "2. b2", prompt.Default)
+	assert.Equal(t, options, prompt.Options)
+	require.NotNil(t, prompt.Filter)
+	assert.True(t, prompt.Filter("resume", options[0], 0), "filter should retain diacritic-insensitive matching")
+}
+
+func TestSwitchCmd_DescribesVimNavigation(t *testing.T) {
+	cfg, _, _ := config.NewTestConfig()
+
+	assert.Contains(t, SwitchCmd(cfg).Long, "down/up arrow keys or j/k")
+}

--- a/docs/src/content/docs/guides/modify.md
+++ b/docs/src/content/docs/guides/modify.md
@@ -55,9 +55,9 @@ Inserts a new empty branch into the stack at the cursor position. Lowercase `i` 
 
 Opens an inline prompt to enter a new name for the branch. The branch is renamed locally and in the stack metadata. On the next `submit`, the new branch name is pushed to GitHub.
 
-### Reorder (`Shift+↑`/`Shift+↓`)
+### Reorder (`Shift+↓`/`Shift+↑`)
 
-Moves the selected branch up (away from trunk) or down (toward trunk) in the stack. A cascading rebase adjusts all affected branches. Note: reordering and structural changes (drop/fold/insert/rename) cannot be mixed in the same session.
+Moves the selected branch down (toward trunk) or up (away from trunk) in the stack. A cascading rebase adjusts all affected branches. Note: reordering and structural changes (drop/fold/insert/rename) cannot be mixed in the same session.
 
 ### Undo (`z`)
 

--- a/docs/src/content/docs/guides/workflows.md
+++ b/docs/src/content/docs/guides/workflows.md
@@ -357,7 +357,7 @@ gh stack modify
 #   u     → fold up (into branch above)
 #   i     → insert below
 #   I     → insert above
-#   Shift+↑/↓ → reorder
+#   Shift+↓/↑ → reorder
 #   r     → rename
 #   z     → undo
 #   Ctrl+S → apply changes
@@ -385,7 +385,7 @@ gh stack submit
 **Reorder branches:**
 1. `gh stack modify`
 2. Navigate to the branch to move
-3. Press `Shift+↑` to move up or `Shift+↓` to move down
+3. Press `Shift+↓` to move down or `Shift+↑` to move up
 4. Press `Ctrl+S` to apply
 5. `gh stack submit`
 

--- a/internal/tui/checkoutview/model.go
+++ b/internal/tui/checkoutview/model.go
@@ -35,6 +35,8 @@ func (t tab) String() string {
 type keyMap struct {
 	Up      key.Binding
 	Down    key.Binding
+	VimUp   key.Binding
+	VimDown key.Binding
 	Select  key.Binding
 	NextTab key.Binding
 	PrevTab key.Binding
@@ -45,6 +47,8 @@ type keyMap struct {
 var keys = keyMap{
 	Up:      key.NewBinding(key.WithKeys("up", "ctrl+p")),
 	Down:    key.NewBinding(key.WithKeys("down", "ctrl+n")),
+	VimUp:   key.NewBinding(key.WithKeys("k")),
+	VimDown: key.NewBinding(key.WithKeys("j")),
 	Select:  key.NewBinding(key.WithKeys("enter")),
 	NextTab: key.NewBinding(key.WithKeys("tab", "right")),
 	PrevTab: key.NewBinding(key.WithKeys("shift+tab", "left")),
@@ -111,11 +115,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.cancelled = true
 		return m, tea.Quit
 
-	case key.Matches(msg, keys.Up):
+	case key.Matches(msg, keys.Up) || (!m.searching && key.Matches(msg, keys.VimUp)):
 		m.moveCursor(-1)
 		return m, nil
 
-	case key.Matches(msg, keys.Down):
+	case key.Matches(msg, keys.Down) || (!m.searching && key.Matches(msg, keys.VimDown)):
 		m.moveCursor(1)
 		return m, nil
 
@@ -563,13 +567,13 @@ func (m Model) renderFooter() string {
 	var pairs [][2]string
 	if m.searching {
 		pairs = [][2]string{
-			{"↑↓", "navigate"},
+			{"↓↑", "navigate"},
 			{"enter", "select"},
 			{"esc", "clear search"},
 		}
 	} else {
 		pairs = [][2]string{
-			{"↑↓", "navigate"},
+			{"↓↑/jk", "navigate"},
 			{"←→", "tabs"},
 			{"/", "search"},
 			{"enter", "select"},

--- a/internal/tui/checkoutview/model_test.go
+++ b/internal/tui/checkoutview/model_test.go
@@ -144,13 +144,25 @@ func TestSearchMatchesMidStackBranch(t *testing.T) {
 }
 
 func TestCursorNavigationClamps(t *testing.T) {
-	m := sized(New(sampleRows()))
-	// Up at the top stays at 0.
-	m = drive(m, tea.KeyMsg{Type: tea.KeyUp})
-	assert.Equal(t, 0, m.cursor)
-	// Down past the end clamps to the last row.
-	m = drive(m, tea.KeyMsg{Type: tea.KeyDown}, tea.KeyMsg{Type: tea.KeyDown}, tea.KeyMsg{Type: tea.KeyDown})
-	assert.Equal(t, 2, m.cursor)
+	tests := []struct {
+		name string
+		up   tea.KeyMsg
+		down tea.KeyMsg
+	}{
+		{name: "arrow keys", up: tea.KeyMsg{Type: tea.KeyUp}, down: tea.KeyMsg{Type: tea.KeyDown}},
+		{name: "vim keys", up: runeKey("k"), down: runeKey("j")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := sized(New(sampleRows()))
+			m = drive(m, tt.up)
+			assert.Equal(t, 0, m.cursor)
+
+			m = drive(m, tt.down, tt.down, tt.down)
+			assert.Equal(t, 2, m.cursor)
+		})
+	}
 }
 
 func TestEnterSelectsLocalRow(t *testing.T) {
@@ -210,6 +222,14 @@ func TestQTypesIntoSearchInsteadOfQuitting(t *testing.T) {
 	assert.False(t, m.Cancelled())
 }
 
+func TestVimKeysTypeIntoSearchInsteadOfNavigating(t *testing.T) {
+	m := sized(New(sampleRows()))
+	m = drive(m, runeKey("/"), runeKey("j"), runeKey("k"))
+
+	assert.True(t, m.searching)
+	assert.Equal(t, "jk", m.query)
+}
+
 func TestView_RendersColumnsAndRows(t *testing.T) {
 	m := sized(New(sampleRows()))
 	out := stripANSI(m.View())
@@ -222,6 +242,7 @@ func TestView_RendersColumnsAndRows(t *testing.T) {
 	assert.Contains(t, out, "Remote")
 	assert.Contains(t, out, "1h ago")
 	assert.Contains(t, out, "/ search")
+	assert.Contains(t, out, "↓↑/jk")
 }
 
 func TestView_SearchFooterAndPrompt(t *testing.T) {
@@ -230,6 +251,8 @@ func TestView_SearchFooterAndPrompt(t *testing.T) {
 	out := stripANSI(m.View())
 	assert.Contains(t, out, "/ a")
 	assert.Contains(t, out, "clear search")
+	assert.Contains(t, out, "↓↑ navigate")
+	assert.NotContains(t, out, "↓↑/jk")
 }
 
 func TestView_EmptyStateMessage(t *testing.T) {

--- a/internal/tui/mergeview/model_test.go
+++ b/internal/tui/mergeview/model_test.go
@@ -29,6 +29,8 @@ func step(m Model, msg tea.Msg) Model {
 
 func keyType(t tea.KeyType) tea.KeyMsg { return tea.KeyMsg{Type: t} }
 
+func keyRune(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
+
 func space() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeySpace} }
 
 func TestNew_DefaultsSelectAll(t *testing.T) {
@@ -124,19 +126,32 @@ func TestSelect_Viewport(t *testing.T) {
 	assert.Contains(t, view, "more")
 }
 
-func TestSelect_ArrowDirection(t *testing.T) {
-	m := New(baseOptions()) // cursor starts at the top of the stack (index 2)
-	assert.Equal(t, 2, m.cursor)
+func TestSelect_NavigationDirection(t *testing.T) {
+	tests := []struct {
+		name string
+		up   tea.KeyMsg
+		down tea.KeyMsg
+	}{
+		{name: "arrow keys", up: keyType(tea.KeyUp), down: keyType(tea.KeyDown)},
+		{name: "vim keys", up: keyRune('k'), down: keyRune('j')},
+	}
 
-	// "up" moves toward the top of the stack and is clamped there.
-	m = step(m, keyType(tea.KeyUp))
-	assert.Equal(t, 2, m.cursor)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New(baseOptions()) // cursor starts at the top of the stack (index 2)
+			assert.Equal(t, 2, m.cursor)
 
-	// "down" moves toward the bottom of the stack (lower index).
-	m = step(m, keyType(tea.KeyDown))
-	assert.Equal(t, 1, m.cursor)
-	m = step(m, keyType(tea.KeyUp))
-	assert.Equal(t, 2, m.cursor)
+			// Up moves toward the top of the stack and is clamped there.
+			m = step(m, tt.up)
+			assert.Equal(t, 2, m.cursor)
+
+			// Down moves toward the bottom of the stack (lower index).
+			m = step(m, tt.down)
+			assert.Equal(t, 1, m.cursor)
+			m = step(m, tt.up)
+			assert.Equal(t, 2, m.cursor)
+		})
+	}
 }
 
 func TestTruncate_WideRunes(t *testing.T) {
@@ -258,6 +273,18 @@ func TestMethod_SelectAndAdvance(t *testing.T) {
 	m = step(m, keyType(tea.KeyEnter))
 	assert.Equal(t, StepConfirm, m.step)
 	assert.Equal(t, "rebase", m.method)
+}
+
+func TestMethod_VimNavigation(t *testing.T) {
+	m := New(baseOptions())
+	m = step(m, keyType(tea.KeyEnter))
+	require.Equal(t, StepMethod, m.step)
+	require.Equal(t, 1, m.methodCursor)
+
+	m = step(m, keyRune('j'))
+	assert.Equal(t, 2, m.methodCursor)
+	m = step(m, keyRune('k'))
+	assert.Equal(t, 1, m.methodCursor)
 }
 
 func TestMethod_EscCancels(t *testing.T) {
@@ -392,9 +419,12 @@ func TestView_RendersBannerAndSteps(t *testing.T) {
 	assert.Contains(t, sel, "Confirm")
 	assert.Contains(t, sel, "Will merge 3 PRs into main")
 	assert.Contains(t, sel, "feat-a") // branch shown on the item's second line
+	assert.Contains(t, sel, "↓↑/jk")
 
 	m = step(m, keyType(tea.KeyTab))
-	assert.Contains(t, m.View(), "Squash and merge") // method labels, no subheading
+	method := m.View()
+	assert.Contains(t, method, "Squash and merge") // method labels, no subheading
+	assert.Contains(t, method, "↓↑/jk")
 
 	m = step(m, keyType(tea.KeyTab))
 	confirm := m.View()

--- a/internal/tui/mergeview/view.go
+++ b/internal/tui/mergeview/view.go
@@ -198,7 +198,7 @@ func (m Model) viewSelect() string {
 	}
 
 	// Reserve the indicator lines at all times (blank when nothing is hidden) so
-	// the list doesn't shift as the ↑/↓ hints appear and disappear while scrolling.
+	// the list doesn't shift as the ↓/↑ hints appear and disappear while scrolling.
 	if start > 0 {
 		b.WriteString(faintStyle.Render(fmt.Sprintf("  ↑ %d more", start)) + "\n")
 	} else {
@@ -251,7 +251,7 @@ func (m Model) viewSelect() string {
 	}
 	b.WriteString("\n\n")
 	b.WriteString(shortcuts(
-		[2]string{"↑/↓", "move"},
+		[2]string{"↓↑/jk", "move"},
 		[2]string{"space", "toggle"},
 		[2]string{"tab/enter", "next"},
 		[2]string{"esc", "cancel"},
@@ -278,7 +278,7 @@ func (m Model) viewMethod() string {
 
 	b.WriteString("\n")
 	b.WriteString(shortcuts(
-		[2]string{"↑/↓", "move"},
+		[2]string{"↓↑/jk", "move"},
 		[2]string{"tab/enter", "next"},
 		[2]string{"shift+tab", "back"},
 		[2]string{"esc", "cancel"},

--- a/internal/tui/modifyview/help.go
+++ b/internal/tui/modifyview/help.go
@@ -37,8 +37,8 @@ func renderHelpOverlay(width, height int) string {
 			"Rename a branch locally. The new name is pushed on submit.",
 		},
 		{
-			"Reorder (Shift+↑/↓)",
-			"Move a branch up or down in the stack.\nA cascading rebase adjusts all affected branches.",
+			"Reorder (Shift+↓/↑)",
+			"Move a branch down or up in the stack.\nA cascading rebase adjusts all affected branches.",
 		},
 	}
 

--- a/internal/tui/modifyview/model.go
+++ b/internal/tui/modifyview/model.go
@@ -35,7 +35,7 @@ type modifyKeyMap struct {
 }
 
 func (k modifyKeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Drop, k.FoldDown, k.InsertBelow, k.Rename, k.ToggleCommits, k.ToggleFiles, k.Apply, k.Help, k.Quit}
+	return []key.Binding{k.Down, k.Up, k.Drop, k.FoldDown, k.InsertBelow, k.Rename, k.ToggleCommits, k.ToggleFiles, k.Apply, k.Help, k.Quit}
 }
 
 func (k modifyKeyMap) FullHelp() [][]key.Binding {
@@ -1483,11 +1483,11 @@ func (m Model) buildHeaderConfig() shared.HeaderConfig {
 		ShortcutColumns: 2,
 		Shortcuts: []shared.ShortcutEntry{
 			// Left column                          // Right column
-			{Key: "↑↓", Desc: "select branch"}, {Key: "x", Desc: "drop", Disabled: structureDisabled},
+			{Key: "↓↑/jk", Desc: "select branch"}, {Key: "x", Desc: "drop", Disabled: structureDisabled},
 			{Key: "f", Desc: "view files"}, {Key: "r", Desc: "rename", Disabled: structureDisabled},
 			{Key: "c", Desc: "view commits"}, {Key: "i/I", Desc: "insert below/above", Disabled: structureDisabled},
 			{Key: "?", Desc: "help"}, {Key: "d/u", Desc: "fold down/up", Disabled: structureDisabled},
-			{Key: "q/esc", Desc: "quit"}, {Key: "shift+↑↓", Desc: "reorder", Disabled: reorderDisabled},
+			{Key: "q/esc", Desc: "quit"}, {Key: "shift+↓↑", Desc: "reorder", Disabled: reorderDisabled},
 			{Key: "^S", Desc: "apply changes"}, {Key: "z", Desc: "undo"},
 		},
 	}

--- a/internal/tui/modifyview/model_test.go
+++ b/internal/tui/modifyview/model_test.go
@@ -1201,6 +1201,14 @@ func TestBranchCountExcludesInserts(t *testing.T) {
 	assert.Contains(t, cfg.InfoLines[1].Label, "3 branches")
 }
 
+func TestHeaderShowsVimNavigationKeys(t *testing.T) {
+	cfg := New([]ModifyBranchNode{makeNode("a", true, 0)}, testTrunk, "1.0.0").buildHeaderConfig()
+
+	require.NotEmpty(t, cfg.Shortcuts)
+	assert.Equal(t, "↓↑/jk", cfg.Shortcuts[0].Key)
+	assert.Equal(t, "select branch", cfg.Shortcuts[0].Desc)
+}
+
 // --- Bug fix tests: operations blocked on inserted nodes ---
 
 func TestCannotRenameInsertedBranch(t *testing.T) {

--- a/internal/tui/stackview/model.go
+++ b/internal/tui/stackview/model.go
@@ -23,7 +23,7 @@ type keyMap struct {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.ToggleCommits, k.ToggleFiles, k.OpenPR, k.Checkout, k.Quit}
+	return []key.Binding{k.Down, k.Up, k.ToggleCommits, k.ToggleFiles, k.OpenPR, k.Checkout, k.Quit}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
@@ -32,12 +32,12 @@ func (k keyMap) FullHelp() [][]key.Binding {
 
 var keys = keyMap{
 	Up: key.NewBinding(
-		key.WithKeys("up"),
-		key.WithHelp("↑", "up"),
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "up"),
 	),
 	Down: key.NewBinding(
-		key.WithKeys("down"),
-		key.WithHelp("↓", "down"),
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "down"),
 	),
 	ToggleCommits: key.NewBinding(
 		key.WithKeys("c"),
@@ -464,7 +464,7 @@ func (m Model) buildHeaderConfig() shared.HeaderConfig {
 		InfoLines:       infoLines,
 		ShortcutColumns: 1,
 		Shortcuts: []shared.ShortcutEntry{
-			{Key: "↑↓", Desc: "navigate", Disabled: allMerged},
+			{Key: "↓↑/jk", Desc: "navigate", Disabled: allMerged},
 			{Key: "c", Desc: "commits", Disabled: allMerged},
 			{Key: "f", Desc: "files", Disabled: allMerged},
 			{Key: "o", Desc: "open PR", Disabled: allMerged},

--- a/internal/tui/stackview/model_test.go
+++ b/internal/tui/stackview/model_test.go
@@ -60,39 +60,45 @@ func TestNew_CursorAtZeroWhenNoCurrent(t *testing.T) {
 }
 
 func TestUpdate_KeyboardNavigation(t *testing.T) {
-	nodes := makeNodes("b1", "b2", "b3")
-	m := New(nodes, testTrunk, "0.0.1", 0)
-	assert.Equal(t, 0, m.cursor)
+	tests := []struct {
+		name string
+		up   string
+		down string
+	}{
+		{name: "arrow keys", up: "up", down: "down"},
+		{name: "vim keys", up: "k", down: "j"},
+	}
 
-	// Down
-	updated, _ := m.Update(keyMsg("down"))
-	m = updated.(Model)
-	assert.Equal(t, 1, m.cursor)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New(makeNodes("b1", "b2", "b3"), testTrunk, "0.0.1", 0)
+			assert.Equal(t, 0, m.cursor)
 
-	// Down again
-	updated, _ = m.Update(keyMsg("down"))
-	m = updated.(Model)
-	assert.Equal(t, 2, m.cursor)
+			updated, _ := m.Update(keyMsg(tt.down))
+			m = updated.(Model)
+			assert.Equal(t, 1, m.cursor)
 
-	// Down at bottom — should clamp
-	updated, _ = m.Update(keyMsg("down"))
-	m = updated.(Model)
-	assert.Equal(t, 2, m.cursor, "cursor should clamp at bottom")
+			updated, _ = m.Update(keyMsg(tt.down))
+			m = updated.(Model)
+			assert.Equal(t, 2, m.cursor)
 
-	// Up
-	updated, _ = m.Update(keyMsg("up"))
-	m = updated.(Model)
-	assert.Equal(t, 1, m.cursor)
+			updated, _ = m.Update(keyMsg(tt.down))
+			m = updated.(Model)
+			assert.Equal(t, 2, m.cursor, "cursor should clamp at bottom")
 
-	// Up
-	updated, _ = m.Update(keyMsg("up"))
-	m = updated.(Model)
-	assert.Equal(t, 0, m.cursor)
+			updated, _ = m.Update(keyMsg(tt.up))
+			m = updated.(Model)
+			assert.Equal(t, 1, m.cursor)
 
-	// Up at top — should clamp
-	updated, _ = m.Update(keyMsg("up"))
-	m = updated.(Model)
-	assert.Equal(t, 0, m.cursor, "cursor should clamp at top")
+			updated, _ = m.Update(keyMsg(tt.up))
+			m = updated.(Model)
+			assert.Equal(t, 0, m.cursor)
+
+			updated, _ = m.Update(keyMsg(tt.up))
+			m = updated.(Model)
+			assert.Equal(t, 0, m.cursor, "cursor should clamp at top")
+		})
+	}
 }
 
 func TestUpdate_ToggleCommits(t *testing.T) {
@@ -344,20 +350,31 @@ func TestScrollClamp_CannotScrollPastContent(t *testing.T) {
 }
 
 func TestUpdate_CursorSkipsMergedBranches(t *testing.T) {
-	nodes := makeNodes("b1", "b2", "b3")
-	nodes[1].Ref.PullRequest = &stack.PullRequestRef{Number: 2, Merged: true}
-	m := New(nodes, testTrunk, "0.0.1", 0)
-	assert.Equal(t, 0, m.cursor, "cursor should start on first non-merged branch")
+	tests := []struct {
+		name string
+		up   string
+		down string
+	}{
+		{name: "arrow keys", up: "up", down: "down"},
+		{name: "vim keys", up: "k", down: "j"},
+	}
 
-	// Down should skip b2 (merged) and land on b3
-	updated, _ := m.Update(keyMsg("down"))
-	m = updated.(Model)
-	assert.Equal(t, 2, m.cursor, "down should skip merged b2 and land on b3")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes := makeNodes("b1", "b2", "b3")
+			nodes[1].Ref.PullRequest = &stack.PullRequestRef{Number: 2, Merged: true}
+			m := New(nodes, testTrunk, "0.0.1", 0)
+			assert.Equal(t, 0, m.cursor, "cursor should start on first non-merged branch")
 
-	// Up should skip b2 (merged) and land back on b1
-	updated, _ = m.Update(keyMsg("up"))
-	m = updated.(Model)
-	assert.Equal(t, 0, m.cursor, "up should skip merged b2 and land on b1")
+			updated, _ := m.Update(keyMsg(tt.down))
+			m = updated.(Model)
+			assert.Equal(t, 2, m.cursor, "%s should skip merged b2 and land on b3", tt.down)
+
+			updated, _ = m.Update(keyMsg(tt.up))
+			m = updated.(Model)
+			assert.Equal(t, 0, m.cursor, "%s should skip merged b2 and land on b1", tt.up)
+		})
+	}
 }
 
 func TestNew_CursorSkipsMergedBranch(t *testing.T) {
@@ -405,16 +422,16 @@ func TestNew_CursorHiddenWhenAllMerged(t *testing.T) {
 }
 
 func TestUpdate_AllMergedCursorStaysHidden(t *testing.T) {
+	for _, navigationKey := range []string{"down", "up", "j", "k"} {
+		t.Run(navigationKey, func(t *testing.T) {
+			m := New(makeAllMergedNodes("b1", "b2", "b3"), testTrunk, "0.0.1", 0)
+			updated, _ := m.Update(keyMsg(navigationKey))
+			m = updated.(Model)
+			assert.Equal(t, -1, m.cursor, "%s should not move the hidden cursor", navigationKey)
+		})
+	}
+
 	m := New(makeAllMergedNodes("b1", "b2", "b3"), testTrunk, "0.0.1", 0)
-
-	updated, _ := m.Update(keyMsg("down"))
-	m = updated.(Model)
-	assert.Equal(t, -1, m.cursor, "down should not move the hidden cursor")
-
-	updated, _ = m.Update(keyMsg("up"))
-	m = updated.(Model)
-	assert.Equal(t, -1, m.cursor, "up should not move the hidden cursor")
-
 	updated, cmd := m.Update(keyMsg("enter"))
 	m = updated.(Model)
 	assert.Equal(t, "", m.CheckoutBranch(), "enter should not check out when all merged")
@@ -452,6 +469,14 @@ func TestBuildHeaderConfig_ShortcutsEnabledWithActiveBranches(t *testing.T) {
 	for _, sc := range cfg.Shortcuts {
 		assert.False(t, sc.Disabled, "%q should be enabled when there are active branches", sc.Desc)
 	}
+}
+
+func TestBuildHeaderConfig_ShowsVimNavigationKeys(t *testing.T) {
+	cfg := New(makeNodes("b1", "b2"), testTrunk, "0.0.1", 0).buildHeaderConfig()
+
+	require.NotEmpty(t, cfg.Shortcuts)
+	assert.Equal(t, "↓↑/jk", cfg.Shortcuts[0].Key)
+	assert.Equal(t, "navigate", cfg.Shortcuts[0].Desc)
 }
 
 func TestBuildHeaderConfig_ShowsStackNumber(t *testing.T) {


### PR DESCRIPTION
- Closes #408 
- Implements #195 

Adds Vim-style `j`/`k` navigation across the interactive `view`, `checkout`, and `switch` flows. The `modify` and `merge` TUIs already supported these keys, so their shortcut hints and related documentation now advertise them consistently.

- Keeps the existing arrow-key behavior and checkout search controls
- Leaves `j`/`k` available as search text while filtering checkout results
- Shows navigation hints in down/up order as `↓↑/jk`

Fyi, I left `submit` unchanged because the autofocused text fields conflicted with literal `j` and `k` inputs