### PR TITLE
submit: fall back to vi when no editor is configured

### DIFF
--- a/internal/tui/submitview/preview.go
+++ b/internal/tui/submitview/preview.go
@@ -93,12 +93,15 @@ func (m Model) handleEditorFinished(msg editorFinishedMsg) (tea.Model, tea.Cmd) 
 }
 
 // resolveEditor returns the configured editor command, checking GH_EDITOR,
-// VISUAL, then EDITOR. It returns "" when none are set.
+// VISUAL, then EDITOR. If none are set, it falls back to vi when available.
 func resolveEditor() string {
 	for _, key := range []string{"GH_EDITOR", "VISUAL", "EDITOR"} {
 		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 			return v
 		}
+	}
+	if _, err := exec.LookPath("vi"); err == nil {
+		return "vi"
 	}
 	return ""
 }

--- a/internal/tui/submitview/preview_test.go
+++ b/internal/tui/submitview/preview_test.go
@@ -2,7 +2,9 @@ package submitview
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -29,6 +31,7 @@ func TestResolveEditor(t *testing.T) {
 	t.Setenv("GH_EDITOR", "")
 	t.Setenv("VISUAL", "")
 	t.Setenv("EDITOR", "")
+	t.Setenv("PATH", "")
 	assert.Equal(t, "", resolveEditor())
 
 	t.Setenv("EDITOR", "nano")
@@ -37,12 +40,27 @@ func TestResolveEditor(t *testing.T) {
 	assert.Equal(t, "vim", resolveEditor())
 	t.Setenv("GH_EDITOR", "code --wait")
 	assert.Equal(t, "code --wait", resolveEditor())
+
+	t.Setenv("GH_EDITOR", "")
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "")
+	binDir := t.TempDir()
+	viName := "vi"
+	if runtime.GOOS == "windows" {
+		viName += ".exe"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, viName), nil, 0o755))
+	t.Setenv("PATH", binDir)
+	assert.Equal(t, "vi", resolveEditor())
+	t.Setenv("EDITOR", "nano")
+	assert.Equal(t, "nano", resolveEditor())
 }
 
 func TestOpenEditor_NoEditorSet(t *testing.T) {
 	t.Setenv("GH_EDITOR", "")
 	t.Setenv("VISUAL", "")
 	t.Setenv("EDITOR", "")
+	t.Setenv("PATH", "")
 
 	m := testModel(t, newNodes())
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})


### PR DESCRIPTION
Updates the submit TUI's external description editor to fall back to `vi` when `EDITOR` env vars are unset.

Configured editors keep their existing precedence. The fallback is only used when `vi` is available on `PATH`. The current inline-edit guidance remains unchanged otherwise.